### PR TITLE
feature: [vt] reject out of retention request

### DIFF
--- a/app/vtselect/traces/query/query.go
+++ b/app/vtselect/traces/query/query.go
@@ -133,7 +133,6 @@ func GetSpanNameList(ctx context.Context, cp *CommonParams, serviceName string) 
 // todo in-memory cache of hot traces.
 func GetTrace(ctx context.Context, cp *CommonParams, traceID string) ([]*Row, error) {
 	currentTime := time.Now()
-
 	// possible partition
 	// query: {trace_id_idx="xx"} AND trace_id:traceID
 	qStr := fmt.Sprintf(`{%s="%d"} AND %s:=%q | fields _time`, otelpb.TraceIDIndexStreamName, xxhash.Sum64String(traceID)%otelpb.TraceIDIndexPartitionCount, otelpb.TraceIDIndexFieldName, traceID)
@@ -143,17 +142,25 @@ func GetTrace(ctx context.Context, cp *CommonParams, traceID string) ([]*Row, er
 	}
 	q.AddPipeLimit(1)
 	traceTimestamp, err := findTraceIDTimeSplitTimeRange(ctx, q, cp)
-	if err != nil {
+	if err != nil && !isOutOfRetentionPeriodError(err) {
 		return nil, fmt.Errorf("cannot find trace_id %q start time: %s", traceID, err)
 	}
 
 	// fast path: trace start time found, search in [trace start time, trace start time + *traceMaxDurationWindow] time range.
 	if !traceTimestamp.IsZero() {
-		return findSpansByTraceIDAndTime(ctx, cp, traceID, traceTimestamp.Add(-*traceMaxDurationWindow), traceTimestamp.Add(*traceMaxDurationWindow))
+		rows, err := findSpansByTraceIDAndTime(ctx, cp, traceID, traceTimestamp.Add(-*traceMaxDurationWindow), traceTimestamp.Add(*traceMaxDurationWindow))
+		if err != nil && isOutOfRetentionPeriodError(err) {
+			return []*Row{}, nil
+		}
+		return rows, err
 	}
 	// slow path: if trace start time not exist, probably the root span was not available.
 	// try to search from now to 0 timestamp.
-	return findSpansByTraceID(ctx, cp, traceID)
+	rows, err := findSpansByTraceID(ctx, cp, traceID)
+	if err != nil && isOutOfRetentionPeriodError(err) {
+		return []*Row{}, nil
+	}
+	return rows, err
 }
 
 // GetTraceList returns multiple traceIDs and spans of them in []*Row format.
@@ -361,7 +368,6 @@ func findTraceIDTimeSplitTimeRange(ctx context.Context, q *logstorage.Query, cp 
 	traceIDStartTimeInt := int64(0)
 	var missingTimeColumn atomic.Bool
 	ctxWithCancel, cancel := context.WithCancel(ctx)
-
 	writeBlock := func(_ uint, db *logstorage.DataBlock) {
 		if missingTimeColumn.Load() {
 			return
@@ -387,7 +393,7 @@ func findTraceIDTimeSplitTimeRange(ctx context.Context, q *logstorage.Query, cp 
 	currentTime := time.Now()
 	startTime := currentTime.Add(-*traceSearchStep)
 	endTime := currentTime
-	for startTime.UnixNano() > 0 { // todo: no need to search time range before retention period.
+	for startTime.UnixNano() > 0 {
 		qq := q.CloneWithTimeFilter(currentTime.UnixNano(), startTime.UnixNano(), endTime.UnixNano())
 		if err := vtstorage.RunQuery(ctxWithCancel, cp.TenantIDs, qq, writeBlock); err != nil {
 			return time.Time{}, err
@@ -406,7 +412,6 @@ func findTraceIDTimeSplitTimeRange(ctx context.Context, q *logstorage.Query, cp 
 		// found result, perform extra search for traceMaxDurationWindow and then break.
 		return time.Unix(traceIDStartTimeInt/1e9, traceIDStartTimeInt%1e9), nil
 	}
-
 	return time.Time{}, nil
 }
 
@@ -460,9 +465,7 @@ func findSpansByTraceIDAndTime(ctx context.Context, cp *CommonParams, traceID st
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse query [%s]: %s", qStr, err)
 	}
-
 	ctxWithCancel, cancel := context.WithCancel(ctx)
-
 	// search for trace spans and write to `rows []*Row`
 	var rowsLock sync.Mutex
 	var rows []*Row
@@ -526,4 +529,8 @@ func checkTraceIDList(traceIDList []string) []string {
 		}
 	}
 	return result
+}
+
+func isOutOfRetentionPeriodError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "out of retention period")
 }

--- a/app/vtstorage/main.go
+++ b/app/vtstorage/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
 	"io"
 	"net/http"
 	"time"
@@ -232,6 +233,19 @@ func RequestHandler(w http.ResponseWriter, r *http.Request) bool {
 	return false
 }
 
+// CheckTimeExceedRetention
+// endTimestamp is a nanosecond timestamp
+func CheckTimeExceedRetention(endTimestamp int64) error {
+	minAllowedTimestamp := int64(fasttime.UnixTimestamp()*1000) - retentionPeriod.Milliseconds()
+	if endTimestamp/1000000 > minAllowedTimestamp {
+		return nil
+	}
+	return &httpserver.ErrorWithStatusCode{
+		Err:        fmt.Errorf("out of retention period. the given time range %d is outside the allowed -retentionPeriod=%s according to -denyQueriesOutsideRetention", endTimestamp, retentionPeriod),
+		StatusCode: http.StatusServiceUnavailable,
+	}
+}
+
 func processForceMerge(w http.ResponseWriter, r *http.Request) bool {
 	if localStorage == nil {
 		// Force merge isn't supported by non-local storage
@@ -349,6 +363,10 @@ func RunQuery(ctx context.Context, tenantIDs []logstorage.TenantID, q *logstorag
 	}
 
 	if localStorage != nil {
+		_, maxTimestamp := q.GetFilterTimeRange()
+		if err := CheckTimeExceedRetention(maxTimestamp); err != nil {
+			return err
+		}
 		return localStorage.RunQuery(ctx, tenantIDs, q, writeBlock)
 	}
 	return netstorageSelect.RunQuery(ctx, tenantIDs, q, writeBlock)

--- a/app/vtstorage/netselect/netselect.go
+++ b/app/vtstorage/netselect/netselect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
 	"io"
 	"math"
 	"net/http"
@@ -136,7 +137,10 @@ func (sn *storageNode) runQuery(ctx context.Context, tenantIDs []logstorage.Tena
 		if err != nil {
 			responseBody = []byte(err.Error())
 		}
-		return fmt.Errorf("unexpected status code for the request to %q: %d; want %d; response: %q", reqURL, resp.StatusCode, http.StatusOK, responseBody)
+		return &httpserver.ErrorWithStatusCode{
+			Err:        fmt.Errorf("unexpected status code for the request to %q: %d; want %d; response: %q", reqURL, resp.StatusCode, http.StatusOK, responseBody),
+			StatusCode: resp.StatusCode,
+		}
 	}
 
 	// read the response


### PR DESCRIPTION
### Describe Your Changes

Reject request that query time range exceeds `retentionPeriod`, and avoiding RPC burst problem caused by querying non-exist TraceID describe in https://github.com/VictoriaMetrics/VictoriaTraces/issues/48

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
