### PR TITLE
correct dependency installation

### DIFF
--- a/deployment/docker/builder/Dockerfile
+++ b/deployment/docker/builder/Dockerfile
@@ -1,14 +1,6 @@
 ARG go_builder_image=non-existing
 FROM $go_builder_image
 STOPSIGNAL SIGINT
-RUN apk add git gcc musl-dev make wget --no-cache && \
-    mkdir /opt/cross-builder && \
-    cd /opt/cross-builder && \
-    for arch in aarch64 x86_64; do \
-        wget \
-            https://github.com/VictoriaMetrics/muslcc-mirror/releases/download/v1.0.0/${arch}-linux-musl-cross.tgz \
-            -O /opt/cross-builder/${arch}-musl.tgz \
-            --no-verbose && \
-        tar zxf ${arch}-musl.tgz -C ./  && \
-        rm /opt/cross-builder/${arch}-musl.tgz; \
-    done
+RUN apt update && apt install -y \
+    gcc-x86-64-linux-gnu \
+    gcc-aarch64-linux-gnu


### PR DESCRIPTION
### Describe Your Changes

This PR fixes the builder errors:

```
0.073 /bin/sh: 1: apk: not found
------
Dockerfile:4
--------------------
   3 |     STOPSIGNAL SIGINT
   4 | >>> RUN apk add git gcc musl-dev make wget --no-cache && \
   5 | >>>     mkdir /opt/cross-builder && \
   6 | >>>     cd /opt/cross-builder && \
   7 | >>>     for arch in aarch64 x86_64; do \
   8 | >>>         wget \
   9 | >>>             https://github.com/VictoriaMetrics/muslcc-mirror/releases/download/v1.0.0/${arch}-linux-musl-cross.tgz \
  10 | >>>             -O /opt/cross-builder/${arch}-musl.tgz \
  11 | >>>             --no-verbose && \
  12 | >>>         tar zxf ${arch}-musl.tgz -C ./  && \
  13 | >>>         rm /opt/cross-builder/${arch}-musl.tgz; \
  14 | >>>     done
```

See also: https://github.com/VictoriaMetrics/VictoriaLogs/pull/581/files

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
