### PR TITLE
Fix: update dashboard descriptions for single node version

### DIFF
--- a/dashboards/victoriatraces.json
+++ b/dashboards/victoriatraces.json
@@ -46,7 +46,7 @@
       }
     ]
   },
-  "description": "Overview for cluster version of VictoriaTraces v0.3.0 or higher",
+  "description": "Overview for single-node version of VictoriaTraces v0.3.0 or higher",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -11464,7 +11464,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "VictoriaTraces - cluster",
+  "title": "VictoriaTraces - single-node",
   "uid": "XqCOFEX6z",
   "version": 1
 }


### PR DESCRIPTION
### Describe Your Changes

VictoriaTraces comes with two dashboards - one for cluster and one for single-node versions. These should have appropriate descriptions set

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
