### PR TITLE
vendor: update metrics package to v1.40.2

### DIFF
--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -13,6 +13,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 ## tip
 
 * SECURITY: upgrade Go builder from Go1.25.0 to Go1.25.1. See [the list of issues addressed in Go1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1%20label%3ACherryPickApproved).
+  
+* BUGFIX: all components: restore sorting order of summary and quantile metrics exposed by VictoriaTraces components on `/metrics` page. See [metrics#105](https://github.com/VictoriaMetrics/metrics/pull/105) for details.
 
 ## [v0.3.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.3.0)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VictoriaMetrics/VictoriaMetrics v0.0.0-20250903201027-a0a33f0ce1c2
 	github.com/VictoriaMetrics/easyproto v0.1.4
 	github.com/VictoriaMetrics/fastcache v1.13.0
-	github.com/VictoriaMetrics/metrics v1.40.1
+	github.com/VictoriaMetrics/metrics v1.40.2
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/valyala/fastjson v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/VictoriaMetrics/fastcache v1.13.0 h1:AW4mheMR5Vd9FkAPUv+NH6Nhw+fmbTMG
 github.com/VictoriaMetrics/fastcache v1.13.0/go.mod h1:hHXhl4DA2fTL2HTZDJFXWgW0LNjo6B+4aj2Wmng3TjU=
 github.com/VictoriaMetrics/metrics v1.40.1 h1:FrF5uJRpIVj9fayWcn8xgiI+FYsKGMslzPuOXjdeyR4=
 github.com/VictoriaMetrics/metrics v1.40.1/go.mod h1:XE4uudAAIRaJE614Tl5HMrtoEU6+GDZO4QTnNSsZRuA=
+github.com/VictoriaMetrics/metrics v1.40.2 h1:OVSjKcQEx6JAwGeu8/KQm9Su5qJ72TMEW4xYn5vw3Ac=
+github.com/VictoriaMetrics/metrics v1.40.2/go.mod h1:XE4uudAAIRaJE614Tl5HMrtoEU6+GDZO4QTnNSsZRuA=
 github.com/VictoriaMetrics/metricsql v0.84.7 h1:zMONjtEULMbwEYU/qL4Hkc3GDfTTrv1bO+a9lmJf3do=
 github.com/VictoriaMetrics/metricsql v0.84.7/go.mod h1:d4EisFO6ONP/HIGDYTAtwrejJBBeKGQYiRl095bS4QQ=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=

--- a/vendor/github.com/VictoriaMetrics/metrics/set.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/set.go
@@ -47,10 +47,10 @@ func (s *Set) WritePrometheus(w io.Writer) {
 			return fName1 < fName2
 		}
 
+		// Only summary and quantile(s) have different metric types.
+		// Sorting by metric type will stabilize the order for summary and quantile(s).
 		mType1 := s.a[i].metric.metricType()
 		mType2 := s.a[j].metric.metricType()
-
-		// stabilize the order for summary and quantiles.
 		if mType1 != mType2 {
 			return mType1 < mType2
 		}

--- a/vendor/github.com/VictoriaMetrics/metrics/summary.go
+++ b/vendor/github.com/VictoriaMetrics/metrics/summary.go
@@ -120,7 +120,13 @@ func (sm *Summary) marshalTo(prefix string, w io.Writer) {
 }
 
 func (sm *Summary) metricType() string {
-	return "summary"
+	// this metric type should not be printed, because summary (sum and count)
+	// of the same metric family will be printed after quantile(s).
+	// If metadata is needed, the metadata from quantile(s) should be used.
+	// quantile will be printed first, so its metrics type won't be printed as metadata.
+	// Printing quantiles before sum and count aligns this code with Prometheus behavior.
+	// See: https://github.com/VictoriaMetrics/metrics/pull/99
+	return "unsupported"
 }
 
 func splitMetricName(name string) (string, string) {
@@ -201,11 +207,7 @@ func (qv *quantileValue) marshalTo(prefix string, w io.Writer) {
 }
 
 func (qv *quantileValue) metricType() string {
-	// this metricsType should not be printed, because summary (sum and count) of the same metric family will be printed first,
-	// and if metadata is needed, the metadata from summary should be used.
-	// quantile will be printed later, so its metrics type won't be printed as metadata.
-	// See: https://github.com/VictoriaMetrics/metrics/pull/99
-	return "unsupported"
+	return "summary"
 }
 
 func addTag(name, tag string) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,7 +49,7 @@ github.com/VictoriaMetrics/easyproto
 # github.com/VictoriaMetrics/fastcache v1.13.0
 ## explicit; go 1.24.0
 github.com/VictoriaMetrics/fastcache
-# github.com/VictoriaMetrics/metrics v1.40.1
+# github.com/VictoriaMetrics/metrics v1.40.2
 ## explicit; go 1.18
 github.com/VictoriaMetrics/metrics
 # github.com/VictoriaMetrics/metricsql v0.84.7


### PR DESCRIPTION
Restore sorting order of summary and quantile metrics exposed by VictoriaTraces components on `/metrics` page.

https://github.com/VictoriaMetrics/metrics/pull/105