### PR TITLE
revert 73fa02fc6a5568460fed2c8f0abfa9d21d692b96

### DIFF
--- a/deployment/docker/base/Dockerfile
+++ b/deployment/docker/base/Dockerfile
@@ -7,7 +7,4 @@ RUN apk update && apk upgrade && apk --update --no-cache add ca-certificates
 
 FROM $root_image
 
-# Temporary fix for CVE-2025-9230, CVE-2025-9231, CVE-2025-9232 until Alpine releases a fixed image.
-RUN apk add --no-cache 'libcrypto3=3.5.4-r0' 'libssl3=3.5.4-r0'
-
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
### Describe Your Changes

Revert 73fa02fc6a5568460fed2c8f0abfa9d21d692b96. Removed temporary fix for CVE-2025-9230, CVE-2025-9231, and CVE-2025-9232 as Alpine has released a fixed image.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
