### PR TITLE
deployment/docker: update Go builder from Go1.25.1 to Go1.25.2

### DIFF
--- a/app/vmui/Dockerfile-web
+++ b/app/vmui/Dockerfile-web
@@ -1,4 +1,4 @@
-FROM golang:1.25.1 AS build-web-stage
+FROM golang:1.25.2 AS build-web-stage
 COPY build /build
 
 WORKDIR /build

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -7,7 +7,7 @@ ROOT_IMAGE ?= alpine:3.22.1
 ROOT_IMAGE_SCRATCH ?= scratch
 CERTS_IMAGE := alpine:3.22.1
 
-GO_BUILDER_IMAGE := golang:1.25.1
+GO_BUILDER_IMAGE := golang:1.25.2
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
 BASE_IMAGE := local/base:1.1.4-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)
 DOCKER ?= docker

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,7 +12,7 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
-* SECURITY: upgrade Go builder from Go1.25.0 to Go1.25.1. See [the list of issues addressed in Go1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1%20label%3ACherryPickApproved).
+* SECURITY: upgrade Go builder from Go1.25.0 to Go1.25.2. See the list of issues addressed in [Go1.25.1](https://github.com/golang/go/issues?q=milestone%3AGo1.25.1%20label%3ACherryPickApproved) and [Go1.25.2](https://github.com/golang/go/issues?q=milestone%3AGo1.25.2%20label%3ACherryPickApproved).
 
 * FEATURE: [logstorage](https://docs.victoriametrics.com/victorialogs/): Upgrade VictoriaLogs dependency from [v1.33.1 to v1.35.0](https://github.com/VictoriaMetrics/VictoriaLogs/compare/v1.33.1...v1.35.0).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VictoriaMetrics/VictoriaTraces
 
-go 1.25.1
+go 1.25.2
 
 require (
 	github.com/VictoriaMetrics/VictoriaLogs v1.35.1-0.20251002105307-b134e33daa38


### PR DESCRIPTION
See https://github.com/golang/go/issues?q=milestone%3AGo1.25.2%20label%3ACherryPickApproved