### PR TITLE
app/vmui: replace `npm ci` with `npm i` in Makefile

### DIFF
--- a/app/vmui/Makefile
+++ b/app/vmui/Makefile
@@ -9,7 +9,7 @@ vmui-run-npm-command: vmui-package-base-image
 		--mount type=bind,src="$(shell pwd)/app/vmui",dst=/build \
 		-w /build/packages/vmui \
 		--entrypoint=/bin/bash \
-		vmui-builder-image -c "npm ci && $(NPM_COMMAND)"
+		vmui-builder-image -c "npm i && $(NPM_COMMAND)"
 
 vmui-build:
 	NPM_COMMAND="npm run build" $(MAKE) vmui-run-npm-command


### PR DESCRIPTION
### Describe Your Changes

Replace `npm ci` with `npm i` in the `Makefile` for dependency installation, which allows the reuse of already installed dependencies and reduces the time of action execution.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
