### PR TITLE
bugfix: fix backward compatibility for the old index format

### DIFF
--- a/app/vtselect/traces/query/query.go
+++ b/app/vtselect/traces/query/query.go
@@ -490,9 +490,8 @@ func findTraceIDTimeSplitTimeRange(ctx context.Context, q *logstorage.Query, cp 
 			// this could be the old format index, which records trace ID and the approximate timestamp only.
 			// to transform this into new format (start time & end time), use [t-traceWindow, t+traceWindow].
 			// this code should be deprecated in the future.
-			timestamp, _ := strconv.ParseInt(timeStr, 10, 64)
-			return time.Unix(timestamp/int64(time.Second), timestamp%int64(time.Second)).Add(-*traceMaxDurationWindow),
-				time.Unix(timestamp/int64(time.Second), timestamp%int64(time.Second)).Add(*traceMaxDurationWindow), nil
+			timestamp, _ := time.Parse(time.RFC3339, timeStr)
+			return timestamp.Add(-*traceMaxDurationWindow), timestamp.Add(*traceMaxDurationWindow), nil
 		}
 
 		traceIDStartTime, _ := strconv.ParseInt(traceIDStartTimeStr, 10, 64)

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): fix backward compatibility for the old index format. Previously, the old index format was not parsed correctly into the start and end timestamps.
+
 ## [v0.7.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.7.0)
 
 * FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): add duration and error metrics for service graph background tasks. Thank @chenlujjj for [the pull request #100](https://github.com/VictoriaMetrics/VictoriaTraces/pull/100).


### PR DESCRIPTION
### Describe Your Changes

fix backward compatibility for the old index format.

Previously, the old index format was not parsed correctly into the start and end timestamps.

This bug was introduced in v0.7.0.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
