### PR TITLE
fix: Jaeger API returns 404 for recently ingested traces   

### DIFF
--- a/app/vtselect/traces/query/query.go
+++ b/app/vtselect/traces/query/query.go
@@ -37,6 +37,8 @@ var (
 		"This limit affects Jaeger's /api/services/*/operations API.")
 
 	latencyOffset = flag.Duration("search.latencyOffset", 30*time.Second, "The time when a trace become visible in query results after the collection. see -insert.traceMaxDuration as well. (default 30s)")
+	recentTraceFallbackWindow = flag.Duration("search.recentTraceFallbackWindow", 5*time.Minute, "The time window for searching span data directly when the trace ID index has not been flushed yet. "+
+		"It affects Jaeger's /api/traces/<trace_id> API.")
 )
 
 var (
@@ -183,8 +185,10 @@ func GetTrace(ctx context.Context, cp *CommonParams, traceID string) ([]*Row, er
 	q.AddPipeOffsetLimit(0, 10)
 	traceStartTime, traceEndTime, err := findTraceIDTimeSplitTimeRange(ctx, q, cp)
 	if err != nil && errors.Is(err, vtstoragecommon.ErrOutOfRetention) {
-		// no hit in the retention period, simply returns empty.
-		return nil, nil
+		// The trace ID index may not have been flushed yet, but span data is already queryable.
+		// Fall back to searching span data directly over a recent time window.
+		recentStart := currentTime.Add(-*recentTraceFallbackWindow)
+		return findSpansByTraceIDAndTime(ctx, cp, traceID, recentStart, currentTime)
 	}
 	if err != nil {
 		// something wrong when trying to find the trace_id's start and end time.


### PR DESCRIPTION
### Describe Your Changes

  Jaeger `GET /api/traces/{id}` returns 404 for ~60s after ingestion, while the same trace is
  immediately queryable via vtselect. This happens because `GetTrace()` relies on the trace ID
  index stream, which hasn't been flushed yet due to the double-buffer delay in vtinsert. When
  the index lookup returns `ErrOutOfRetention`, it returns empty instead of falling back to
  span data.

  This change adds a fallback to search span data directly via `findSpansByTraceIDAndTime()`
  over a recent time window when the index is not yet available. The fallback window is
  configurable via `-search.recentTraceFallbackWindow` (default 5m).

  ### Checklist

  The following checks are **mandatory**:

  - [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriamet
  rics.com/victoriametrics/contributing/#pull-request-checklist).
  - [x] My change adheres to [VictoriaMetrics development
  goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Jaeger GET /api/traces/{id} returning 404 for ~60s after ingestion by falling back to span search when the trace ID index hasn’t flushed yet. Adds -search.recentTraceFallbackWindow (default 5m) to define the recent window for this fallback.

<sup>Written for commit 41f09b5062d69613924ec2cdb65b812e51ec51b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

