### PR TITLE
feat(jaeger): add regex support for tag search in /api/traces

### DIFF
--- a/app/vtselect/traces/query/query.go
+++ b/app/vtselect/traces/query/query.go
@@ -229,7 +229,12 @@ func getTraceIDList(ctx context.Context, cp *tracecommon.CommonParams, param *Tr
 	}
 	if len(param.Attributes) > 0 {
 		for k, v := range param.Attributes {
-			qStr += fmt.Sprintf(`AND %q:=%q `, k, v)
+			if strings.HasPrefix(v, "~") {
+				// ~ prefix forces regex (e.g. tags={"key":"~value.*"})
+				qStr += fmt.Sprintf(`AND %q:re(%s) `, k, strconv.Quote(v[1:]))
+			} else {
+				qStr += fmt.Sprintf(`AND %q:=%q `, k, v)
+			}
 		}
 	}
 	if param.DurationMin > 0 {

--- a/apptest/tests/otlp_ingestion_test.go
+++ b/apptest/tests/otlp_ingestion_test.go
@@ -250,6 +250,7 @@ func getDefaultIngestRequestAndAssertFunc(tc *at.TestCase, sut at.VictoriaTraces
 				cmpopts.IgnoreFields(at.JaegerAPITracesResponse{}, "Errors", "Limit", "Offset", "Total"),
 			},
 		})
+
 		// check single trace data via /select/jaeger/api/traces/<trace_id>
 		tc.Assert(&at.AssertOptions{
 			Msg: "unexpected /select/jaeger/api/traces/<trace_id> response",
@@ -261,6 +262,52 @@ func getDefaultIngestRequestAndAssertFunc(tc *at.TestCase, sut at.VictoriaTraces
 			},
 			CmpOpts: []cmp.Option{
 				cmpopts.IgnoreFields(at.JaegerAPITraceResponse{}, "Errors", "Limit", "Offset", "Total"),
+			},
+		})
+
+		// check traces data via /select/jaeger/api/traces with regex tag filter: NOT match, empty result
+		tc.Assert(&at.AssertOptions{
+			Msg: "unexpected /select/jaeger/api/traces response",
+			Got: func() any {
+				return sut.JaegerAPITraces(t, at.JaegerQueryParam{
+					TraceQueryParam: query.TraceQueryParam{
+						ServiceName:  serviceName,
+						StartTimeMin: spanTime.Add(-10 * time.Minute),
+						StartTimeMax: spanTime.Add(10 * time.Minute),
+						Attributes: map[string]string{
+							"testTag": "~INVALID.*",
+						},
+					},
+				}, at.QueryOpts{})
+			},
+			Want: &at.JaegerAPITracesResponse{
+				Data: []at.TracesResponseData{},
+			},
+			CmpOpts: []cmp.Option{
+				cmpopts.IgnoreFields(at.JaegerAPITracesResponse{}, "Errors", "Limit", "Offset", "Total"),
+			},
+		})
+
+		// check traces data via /select/jaeger/api/traces with regex tag filter: match
+		tc.Assert(&at.AssertOptions{
+			Msg: "unexpected /select/jaeger/api/traces response",
+			Got: func() any {
+				return sut.JaegerAPITraces(t, at.JaegerQueryParam{
+					TraceQueryParam: query.TraceQueryParam{
+						ServiceName:  serviceName,
+						StartTimeMin: spanTime.Add(-10 * time.Minute),
+						StartTimeMax: spanTime.Add(10 * time.Minute),
+						Attributes: map[string]string{
+							"testTag": "~test.*",
+						},
+					},
+				}, at.QueryOpts{})
+			},
+			Want: &at.JaegerAPITracesResponse{
+				Data: expectTraceData,
+			},
+			CmpOpts: []cmp.Option{
+				cmpopts.IgnoreFields(at.JaegerAPITracesResponse{}, "Errors", "Limit", "Offset", "Total"),
 			},
 		})
 	}

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): support positive regex matching in the Jaeger query API when filtering traces by tags. See [the pull request #100](https://github.com/VictoriaMetrics/VictoriaTraces/pull/116) for examples. Thank @emamihe for the pull request.
+
 ## [v0.8.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.8.0)
 
 Released at 2026-03-02

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,7 +12,7 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
-* FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): support positive regex matching in the Jaeger query API when filtering traces by tags. See [the pull request #100](https://github.com/VictoriaMetrics/VictoriaTraces/pull/116) for examples. Thank @emamihe for the pull request.
+* FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): support positive regex matching in the Jaeger query API when filtering traces by tags. See [the pull request #116](https://github.com/VictoriaMetrics/VictoriaTraces/pull/116) for examples. Thank @emamihe for the pull request.
 
 ## [v0.8.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.8.0)
 

--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -59,7 +59,7 @@ The `/select/jaeger/api/traces` HTTP endpoint provides the following params:
 
 - `service`: the service name.
 - `operation`: the span name (also known as the operation name in Jaeger).
-- `tags`: the attributes (also known as tags) filter, example: `{"key":"value"}`
+- `tags`: the attributes (also known as tags) filter, example: `{"key":"value"}`. Prefix a value with `~` to use regex matching, e.g. `{"key":"~value.*"}`
 - `start`: the start timestamp in unix microseconds.
 - `end`: the end timestamp in unix microseconds.
 - `minDuration`: the minimum duration of the span, with units `ns`, `us`, `ms`, `s`, `m`, or `h`.
@@ -216,3 +216,4 @@ Some valid filter examples:
 - Multiple span attribute filters: `error=unset otel.scope.name=redis-manual`
 - Single resource attribute filter: `resource_attr:telemetry.sdk.language=go`
 - Span attribute and resource attribute filters: `span.kind=client resource_attr:os.type=linux`
+- Regex filter: prefix the value with `~` to match by regex, e.g. `{"order_id":"~abc.*"}` or `{"http.status_code":"~^2"}` for values starting with "2"

--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -216,4 +216,6 @@ Some valid filter examples:
 - Multiple span attribute filters: `error=unset otel.scope.name=redis-manual`
 - Single resource attribute filter: `resource_attr:telemetry.sdk.language=go`
 - Span attribute and resource attribute filters: `span.kind=client resource_attr:os.type=linux`
-- Regex filter: prefix the value with `~` to match by regex, e.g. `{"order_id":"~abc.*"}` or `{"http.status_code":"~^2"}` for values starting with "2"
+- Multiple regex filters: `span.kind=~cli.* http.status_code:~^2`
+
+Note that the examples are for user input on the Jaeger frontend, which parses and sends the request in JSON format later.


### PR DESCRIPTION
### Describe Your Changes

This PR adds regex support for tag values when searching traces via the Jaeger `/select/jaeger/api/traces` endpoint. 

**Behavior:**
- Tag values prefixed with `~` are treated as regex patterns.
- Tag values without `~` keep exact-match behavior.

**Examples:**
- `tags={"http.status_code":"~^2"}` – matches 200, 201, 2xx, etc.
- `tags={"order_id":"~abc.*"}` – matches values starting with "abc"
- `tags={"key":"value"}` – exact match (unchanged)

**Implementation:**
- Regex filters are built as LogsQL `field:re("regex")` and executed by the VictoriaLogs storage engine.
- The `~` prefix is stripped before passing the value to the regex engine.

**Files changed:**
- `app/vtselect/traces/query/query.go` – logic for tag values with `~` prefix
- `docs/victoriatraces/querying/README.md` – documentation and examples for the `~` prefix

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regex support for tag filters in the Jaeger `/select/jaeger/api/traces` endpoint. Prefix a tag value with `~` to use regex; non-prefixed values remain exact matches.

- **New Features**
  - `~` values translate to LogsQL `field:re("...")` with proper quoting and run by VictoriaLogs.
  - Docs updated (tags param note, JSON and Jaeger UI examples incl. multiple regex filters); changelog notes support for single-node and cluster `vtselect`; apptest adds match and no‑match cases.

<sup>Written for commit 963249e48543e906e98c44f8cc57a8d2d20fe0df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

