### PR TITLE
lib/netutil: add NextProtos to tls.Config for HTTP/2 ALPN negotiation

### DIFF
--- a/app/vtinsert/main.go
+++ b/app/vtinsert/main.go
@@ -4,15 +4,15 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/VictoriaMetrics/VictoriaTraces/app/vtinsert/insertutil"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/netutil"
+	"github.com/VictoriaMetrics/VictoriaTraces/lib/netutil"
 
+	"github.com/VictoriaMetrics/VictoriaTraces/app/vtinsert/insertutil"
 	"github.com/VictoriaMetrics/VictoriaTraces/app/vtinsert/internalinsert"
 	"github.com/VictoriaMetrics/VictoriaTraces/app/vtinsert/opentelemetry"
 	"github.com/VictoriaMetrics/VictoriaTraces/lib/grpc"

--- a/lib/netutil/tls.go
+++ b/lib/netutil/tls.go
@@ -1,0 +1,115 @@
+package netutil
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fasttime"
+)
+
+// GetServerTLSConfig returns TLS config for the server.
+func GetServerTLSConfig(tlsCertFile, tlsKeyFile, tlsMinVersion string, tlsCipherSuites []string) (*tls.Config, error) {
+	_, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load TLS certificate and key files: %w", err)
+	}
+
+	minVersion, err := ParseTLSVersion(tlsMinVersion)
+	if err != nil {
+		return nil, fmt.Errorf("cannot use TLS min version from tlsMinVersion=%q. Supported TLS versions (TLS10, TLS11, TLS12, TLS13): %w", tlsMinVersion, err)
+	}
+	cipherSuites, err := cipherSuitesFromNames(tlsCipherSuites)
+	if err != nil {
+		return nil, fmt.Errorf("cannot use TLS cipher suites from tlsCipherSuites=%q: %w", tlsCipherSuites, err)
+	}
+	cfg := &tls.Config{
+		MinVersion: minVersion,
+
+		// Do not set MaxVersion, since this has no sense from security PoV.
+		// This can only result in lower security level if improperly set.
+
+		CipherSuites: cipherSuites,
+
+		// Enable HTTP/2 and HTTP/1.1 support for TLS listeners via ALPN.
+		// See https://datatracker.ietf.org/doc/html/rfc7540#section-3.3
+		// See https://github.com/VictoriaMetrics/VictoriaTraces/issues/108
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+
+	cfg.GetCertificate = newGetCertificateFunc(tlsCertFile, tlsKeyFile)
+	return cfg, nil
+}
+
+func newGetCertificateFunc(tlsCertFile, tlsKeyFile string) func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	var certLock sync.Mutex
+	var certDeadline uint64
+	var cert *tls.Certificate
+	return func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		certLock.Lock()
+		defer certLock.Unlock()
+		if fasttime.UnixTimestamp() > certDeadline {
+			c, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("cannot load TLS cert from certFile=%q, keyFile=%q: %w", tlsCertFile, tlsKeyFile, err)
+			}
+			certDeadline = fasttime.UnixTimestamp() + 1
+			cert = &c
+		}
+		return cert, nil
+	}
+}
+
+func cipherSuitesFromNames(cipherSuiteNames []string) ([]uint16, error) {
+	if len(cipherSuiteNames) == 0 {
+		return nil, nil
+	}
+
+	css := tls.CipherSuites()
+
+	cssByName := make(map[string]uint16, len(css))
+	for _, cs := range css {
+		cssByName[strings.ToLower(cs.Name)] = cs.ID
+	}
+
+	cssByID := make(map[uint16]bool, len(css))
+	for _, cs := range css {
+		cssByID[cs.ID] = true
+	}
+
+	cipherSuites := make([]uint16, 0, len(cipherSuiteNames))
+	for _, name := range cipherSuiteNames {
+		id, ok := cssByName[strings.ToLower(name)]
+		if !ok {
+			// Try searching by ID
+			idKey, err := strconv.ParseUint(name, 0, 16)
+			if err != nil || !cssByID[uint16(idKey)] {
+				return nil, fmt.Errorf("unsupported TLS cipher suite name: %s", name)
+			}
+			id = uint16(idKey)
+		}
+		cipherSuites = append(cipherSuites, id)
+	}
+	return cipherSuites, nil
+}
+
+// ParseTLSVersion returns tls version from the given string s.
+func ParseTLSVersion(s string) (uint16, error) {
+	switch strings.ToUpper(s) {
+	case "":
+		// Special case - use default TLS version provided by tls package.
+		return 0, nil
+	case "TLS13":
+		return tls.VersionTLS13, nil
+	case "TLS12":
+		return tls.VersionTLS12, nil
+	case "TLS11":
+		return tls.VersionTLS11, nil
+	case "TLS10":
+		return tls.VersionTLS10, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version %q", s)
+	}
+}

--- a/lib/netutil/tls_test.go
+++ b/lib/netutil/tls_test.go
@@ -1,0 +1,290 @@
+package netutil
+
+import (
+	"crypto/tls"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
+)
+
+func TestCipherSuitesFromNamesSucces(t *testing.T) {
+	f := func(cipherSuites []string, expectedSuites []uint16) {
+		t.Helper()
+
+		suites, err := cipherSuitesFromNames(cipherSuites)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(suites, expectedSuites) {
+			t.Fatalf("unexpected ciphersuites; got %d; want %d", suites, expectedSuites)
+		}
+	}
+
+	// Empty ciphersuites
+	f(nil, nil)
+
+	// Supported ciphersuites uppercase
+	f([]string{
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+	}, []uint16{
+		0xc013,
+		0xc014,
+	})
+
+	// Supported ciphersuites lowercase
+	f([]string{
+		"tls_ecdhe_rsa_with_aes_128_cbc_sha",
+		"tls_ecdhe_rsa_with_aes_256_cbc_sha",
+	}, []uint16{
+		0xc013,
+		0xc014,
+	})
+
+	// Correct ciphersuites via numbers
+	f([]string{"0xC013", "0xC014"}, []uint16{0xc013, 0xc014})
+	f([]string{"0xc013", "0xc014"}, []uint16{0xc013, 0xc014})
+}
+
+func TestCipherSuitesFromNamesFailure(t *testing.T) {
+	f := func(cipherSuites []string) {
+		t.Helper()
+		_, err := cipherSuitesFromNames(cipherSuites)
+		if err == nil {
+			t.Fatalf("expecting non-nil error")
+		}
+	}
+
+	// wrong ciphersuite
+	f([]string{"non-existing-ciphersuite"})
+	f([]string{"23432"})
+	f([]string{"2343223432423"})
+
+	// insecure ciphersuites
+	f([]string{"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", "TLS_ECDHE_RSA_WITH_RC4_128_SHA"})
+
+	// insecure ciphersuite numbers
+	f([]string{"0x0005", "0x000a"})
+}
+
+func TestParseTLSVersionSuccess(t *testing.T) {
+	f := func(s string, want uint16) {
+		t.Helper()
+		got, err := ParseTLSVersion(s)
+		if err != nil {
+			t.Fatalf("unexpected error for ParseTLSVersion(%q): %s", s, err)
+		}
+		if got != want {
+			t.Fatalf("unexpected value got from ParseTLSVersion(%q); got %d; want %d", s, got, want)
+		}
+	}
+	// lowercase tlsName
+	f("tls10", tls.VersionTLS10)
+	f("tls11", tls.VersionTLS11)
+	f("tls12", tls.VersionTLS12)
+	f("tls13", tls.VersionTLS13)
+	// uppercase tlsName
+	f("TLS10", tls.VersionTLS10)
+	f("TLS11", tls.VersionTLS11)
+	f("TLS12", tls.VersionTLS12)
+	f("TLS13", tls.VersionTLS13)
+	// empty tlsName
+	f("", 0)
+}
+
+func TestParseTLSVersionFailure(t *testing.T) {
+	f := func(s string) {
+		t.Helper()
+		_, err := ParseTLSVersion(s)
+		if err == nil {
+			t.Fatalf("expecting non-nil error for ParseTLSVersion(%q)", s)
+		}
+	}
+	// incorrect tlsName
+	f("123")
+	// incorrect tlsName with correct prefix
+	f("TLS1")
+	// incorrect tls version in tlsName
+	f("TLS14")
+}
+
+func TestGetServerTLSConfig(t *testing.T) {
+	f := func(tlsCertFile, tlsKeyFile string, expectErr bool) {
+		t.Helper()
+		_, err := GetServerTLSConfig(tlsCertFile, tlsKeyFile, "", []string{})
+		if !errors.Is(err, nil) != expectErr { // same as: if errors.Is(err, nil) == expectErr {
+			t.Fatalf("expect err: %v, get error: %v", expectErr, err)
+		}
+	}
+
+	mustCreateFile("test.crt", testCRT)
+	mustCreateFile("test.key", testPK)
+	defer func() {
+		fs.MustRemovePath("test.crt")
+		fs.MustRemovePath("test.key")
+	}()
+
+	// check cert file not exist
+	f("/a", "./test.key", true)
+	// check key file not exist
+	f("./test.crt", "/b", true)
+	// cert file and key file all exist
+	f("./test.crt", "./test.key", false)
+}
+
+func TestGetServerTLSConfig_RealSignature(t *testing.T) {
+	// Prepare test certificate files
+	certFile := "test.crt"
+	keyFile := "test.key"
+	mustCreateFile(certFile, testCRT)
+	mustCreateFile(keyFile, testPK)
+	defer func() {
+		os.Remove(certFile)
+		os.Remove(keyFile)
+	}()
+
+	// f is the core test helper: calls GetServerTLSConfig and validates the result.
+	f := func(minVer string, ciphers []string, expectErr bool) {
+		t.Helper()
+		cfg, err := GetServerTLSConfig(certFile, keyFile, minVer, ciphers)
+		if (err != nil) != expectErr {
+			t.Fatalf("minVer=%s ciphers=%v | expectErr=%v got err=%v", minVer, ciphers, expectErr, err)
+		}
+		if err != nil {
+			return
+		}
+
+		// Assertion 1: NextProtos must contain both "h2" and "http/1.1" for ALPN negotiation.
+		// Required by RFC 7540 §3.3 so that gRPC-go 1.67+ can negotiate HTTP/2 over TLS.
+		// This guard prevents accidental removal of the NextProtos field in the future.
+		wantProtos := map[string]bool{"h2": false, "http/1.1": false}
+		for _, proto := range cfg.NextProtos {
+			if _, ok := wantProtos[proto]; ok {
+				wantProtos[proto] = true
+			}
+		}
+		for proto, found := range wantProtos {
+			if !found {
+				t.Errorf("NextProtos missing %q, got: %v", proto, cfg.NextProtos)
+			}
+		}
+
+		// Assertion 2: CipherSuites count must match the requested ciphers.
+		if len(ciphers) > 0 && len(cfg.CipherSuites) != len(ciphers) {
+			t.Errorf("CipherSuites count mismatch: want %d, got %d", len(ciphers), len(cfg.CipherSuites))
+		}
+
+		// Assertion 3: MinVersion must be set to a non-zero value.
+		if cfg.MinVersion == 0 {
+			t.Errorf("MinVersion is 0, expected a valid TLS version constant")
+		}
+	}
+
+	// --- Test cases ---
+
+	// Happy path: TLS 1.2 with a standard cipher suite.
+	t.Run("Valid_TLS12_WithCipher", func(t *testing.T) {
+		f("TLS12", []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}, false)
+	})
+
+	// Happy path: TLS 1.3 — cipher suites are ignored by Go's TLS stack for 1.3,
+	// so passing nil should succeed and fall back to Go defaults.
+	t.Run("Valid_TLS13_NilCiphers", func(t *testing.T) {
+		f("TLS13", nil, false)
+	})
+
+	// Happy path: empty cipher slice should fall back to Go's default cipher list.
+	t.Run("Valid_TLS12_EmptyCiphers", func(t *testing.T) {
+		f("TLS12", []string{}, false)
+	})
+
+	// Happy path: nil cipher slice should behave the same as empty.
+	t.Run("Valid_TLS12_NilCiphers", func(t *testing.T) {
+		f("TLS12", nil, false)
+	})
+
+	// Error path: unsupported TLS version string should return an error.
+	t.Run("Invalid_TLS_Version", func(t *testing.T) {
+		f("TLS99", nil, true)
+	})
+
+	// Error path: unrecognized cipher suite name should return an error.
+	t.Run("Invalid_CipherSuite_Name", func(t *testing.T) {
+		f("TLS12", []string{"NON_EXISTENT_CIPHER"}, true)
+	})
+
+	// Error path: non-existent certificate file should return an error.
+	t.Run("Invalid_CertFile_Path", func(t *testing.T) {
+		_, err := GetServerTLSConfig("nonexistent.crt", keyFile, "TLS12", nil)
+		if err == nil {
+			t.Fatal("expected error for missing cert file, got nil")
+		}
+	})
+
+	// Error path: non-existent key file should return an error.
+	t.Run("Invalid_KeyFile_Path", func(t *testing.T) {
+		_, err := GetServerTLSConfig(certFile, "nonexistent.key", "TLS12", nil)
+		if err == nil {
+			t.Fatal("expected error for missing key file, got nil")
+		}
+	})
+}
+
+const (
+	testCRT = `-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUKm1UQfHNrw+b2T+ARui1PJexOpswDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDA3MTAwMzQ1MzVaFw0yNzA3
+MTAwMzQ1MzVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCgdbQ0yIk170LSfhPzrm6LuclwjxGSC31CmmF+BZUH
+J19n33BrL++Rfrfz3kMr5JgfVgjeHWZ2PrLp9M9Jf9eXbcpPcPbPKm3rh1VsdNHX
+o82BQ0+/pOimpWtA88A1F/XyWqC7b94531oaAOLuQzWWXeUFY4A9WlC6hkNgRj32
+EIfuioEXl22pGvQqScgJOJY5nnSFLUvymKUviMTNllIQd8kdNFcz2uKKozoWl9q9
+sNHxGZKTa0dfKjeok8X1pybOZK1E7JLUQBi4oPvI6YAKBFV0BTjkqu6ZBMZE1aPe
+RxGdGx/fugVc2b3ON6+xfY/gaVjL1eyVG5zI6Z8xB0A3AgMBAAGjUzBRMB0GA1Ud
+DgQWBBSetpW1wdKL3jKgHOj0BGX4TKRyHjAfBgNVHSMEGDAWgBSetpW1wdKL3jKg
+HOj0BGX4TKRyHjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBU
+gyYMzjtDq1/DF48tAnBRFomnzzUsAV2NnuMzPF6mN2kxJunyukFpCLMKYeE4d+Jn
+iSDXehLY1pCzKHntTQuqavSOy4uvlboPGFbBuXuR2XYWNqH+wPRd55UtnMntAvBd
+Ovec9+1MW5x0RNiiwZqZ3/oRH3CS7c3iRNMq/AXGNWomE1QXT9ujXR+86KuTBS4h
+uQB6i6TyKuqzydD9nsqwuviOA7xrAthw6cqrAjgo8KBMJpFavsasnd/cZ+8YQqOW
+fTEsNj4PXjYkQP6z6FW/pbNeJLkjuSIwmcs1m5t2bV5oF2kpx+NyqGW0TcYaw3KY
+sWswtTQyQldPeQIkIz1p
+-----END CERTIFICATE-----`
+	testPK = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCgdbQ0yIk170LS
+fhPzrm6LuclwjxGSC31CmmF+BZUHJ19n33BrL++Rfrfz3kMr5JgfVgjeHWZ2PrLp
+9M9Jf9eXbcpPcPbPKm3rh1VsdNHXo82BQ0+/pOimpWtA88A1F/XyWqC7b94531oa
+AOLuQzWWXeUFY4A9WlC6hkNgRj32EIfuioEXl22pGvQqScgJOJY5nnSFLUvymKUv
+iMTNllIQd8kdNFcz2uKKozoWl9q9sNHxGZKTa0dfKjeok8X1pybOZK1E7JLUQBi4
+oPvI6YAKBFV0BTjkqu6ZBMZE1aPeRxGdGx/fugVc2b3ON6+xfY/gaVjL1eyVG5zI
+6Z8xB0A3AgMBAAECggEADG12rWc3YqiAcz9q5ILcMqaLM1RkBtIspkBruvAhaIzu
+8Y4Xgw29jyC9Nujo00OgrpNMxjCJE4Zr9/0geC+rxHbZ5kjjAgzmDN8N9C5LZFle
+R3EtrN5PsJHQ7+u7tWurflTw7E4lQYk1eBxydwQDPf1RXsH5QtyLB8ScqkkLxSdy
+LztMqwu6w9c0TEuzkKMaVgz0xSj2+FLN6yzAQQJUKRCPLff+uKlQx769JA9sji1C
+wxcbSJZXdy0EwkGW/4EjGEPxGxZKunSrlem5A5/RPsfFtDo0DWRzZNCt022TVD/X
+QesFDt6iZXpo9QUmSPiw25pZn4QD/7bNqePyLxNhLQKBgQDBc+I5WXceSNl5tXOL
+UTLkSJaG0R3tBdtQY+Rc0KEQsHi0we968O0BbdFgvdwJw3YWzqm3QtAflgn4GP4X
+1pg7CiCy+8cQFY2TShDJpQ//Z0GwDNUeb9I8cevIsONxRsxVphXovRN7/UFc+Hpi
+Gnibm/lC9w4F8nXouBCvFzQX3QKBgQDUVv39xUjlBY7qFgTayDY7VfH5HNXgbW+f
+sU56EqHtl0VDsDwgI5+91q4uK/X6m0T7FdW1Ua8iKUf+keDzOJR8HeMF01OzpWJR
+p/Wqns1P60KGZv/OWn52J7uYMIslU+VyMvCn58QrrRtchJE3QgVKZUcC5kqpWFul
+SXax7h6hIwKBgG+OxTlvNzsWpZsDIXOIysFMfsmWFBzYUMXGJS3E/ezi52jNoa2S
+/Anj62dPdXGH7zRtzv8on15npq4Us4rJrJX3XC369at30mHKx22RK22MfRvp+oiH
+0YQb6e2c3Dw5qKIHmgDR8EeDH0te2yxxuXV6974/PC3/yTD/3FcsGVVdAoGAMeSK
+46ECgsWukfRAicO3cnO8WoNbAdPVAZngzbApGjGMFd6IEikstKeH39N2hb8ME09L
+GsKpuwYmI3vVdnDZ+tvu5wSDy1dV5cfoYoHTzi6CQCBdhPggdNTbMGRfnZK7+/xa
+Lam4n2aaYj/H+0rpAVUQvW6tJmNbjVfYqvA/hC8CgYB8gqUIhP4yz15P2936g8bS
+uhNX7Msd6fwLsq/5Hn1j+7oCQ3KfvxOnFUFRDIUQvpLsa38rfn1u06gSXkSoM/3m
+WN7PV6auY4J9vhiJcDHLYKWU6IiDPXa2K0EsGarWy1ncJQdpjZPT1Urft2pNF9gP
+YwXfJbKUZnJlv9XplwR7Dw==
+-----END PRIVATE KEY-----`
+)
+
+func mustCreateFile(path, contents string) {
+	fs.MustWriteSync(path, []byte(contents))
+}


### PR DESCRIPTION
### Describe Your Changes

Add `NextProtos: []string{"h2", "http/1.1"}` to the `tls.Config` struct in `lib/netutil/tls.go`.

Without this field, the TLS layer does not advertise HTTP/2 support during the ALPN (Application-Layer Protocol Negotiation) handshake. This causes gRPC clients (including grpc-go v1.67+, which enforces ALPN-based HTTP/2 negotiation) to fail when connecting over TLS, as the server never signals readiness to speak HTTP/2.

Per [RFC 7540 §3.3](https://datatracker.ietf.org/doc/html/rfc7540#section-3.3), HTTP/2 over TLS **must** be negotiated via ALPN using the `h2` identifier. The `http/1.1` entry is included alongside it to preserve backward compatibility with HTTP/1.1-only clients.


### Detailed reproduction steps can be found here:
[#108 comment](https://github.com/VictoriaMetrics/VictoriaTraces/issues/108#issuecomment-4241779139)


### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable HTTP/2 ALPN negotiation by setting `NextProtos` in server TLS config, fixing TLS gRPC connections that require ALPN (e.g., `grpc-go` v1.67+). HTTP/1.1 clients continue to work.

- **Bug Fixes**
  - Add `NextProtos: []string{"h2", "http/1.1"}` in `lib/netutil`’s new `GetServerTLSConfig` to advertise HTTP/2 via ALPN.
  - Add TLS helpers for min version parsing, cipher suite mapping, and lazy cert reload; include tests that verify `h2` is negotiated.
  - Update `app/vtinsert` to import local `lib/netutil`.

<sup>Written for commit 564d3bfb0c133686d1cb0116a19cdbdc14c9bfc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

