### PR TITLE
fix(traceql): map TraceQL `=~` operator to LogsQL `~` operator

### DIFF
--- a/lib/traceql/filter_general.go
+++ b/lib/traceql/filter_general.go
@@ -23,7 +23,24 @@ func (fc *filterCommon) String() string {
 	if duration, ok := tryParseDuration(v); ok {
 		v = strconv.FormatInt(duration, 10)
 	}
-	return quoteFieldNameIfNeeded(fc.tagToVTField()) + ":" + fc.op + quoteTokenIfNeeded(v)
+	return quoteFieldNameIfNeeded(fc.tagToVTField()) + ":" + mapTraceQLOpToLogsQL(fc.op) + quoteTokenIfNeeded(v)
+}
+
+// mapTraceQLOpToLogsQL maps a TraceQL comparison operator to the
+// corresponding LogsQL operator used when composing queries against
+// the underlying VictoriaLogs storage engine.
+//
+// TraceQL regex match operator is `=~` / `!~`, while LogsQL uses
+// `~` / `!~`. Without this mapping the produced LogsQL contains
+// `field:=~"pattern"` which fails to parse with
+//
+//	compound token cannot start with "=~"; put it into quotes if needed
+func mapTraceQLOpToLogsQL(op string) string {
+	switch op {
+	case "=~":
+		return "~"
+	}
+	return op
 }
 
 func (fc *filterCommon) tagToVTField() string {

--- a/lib/traceql/parser_test.go
+++ b/lib/traceql/parser_test.go
@@ -2,6 +2,7 @@ package traceql
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -75,6 +76,43 @@ func Test_parseQuery(t *testing.T) {
 	//f(`{ span.http.request_content_length > "10 * 1024 * 1024" }`)
 	//f(`{ span.http.request_content_length > 10} | select(span.http.request_content_length) | by(span.http.request_content_length, span.http.request_content_length2) | sum(other_field) > 2m`)
 	f(`{(a=b && c=d && c=d)}`)
+}
+
+// TestFilterGeneralString_OperatorMapping verifies that TraceQL comparison
+// operators are translated to valid LogsQL operators when composing
+// the underlying storage query. See lib/traceql/filter_general.go.
+//
+// This guards against a regression where `=~` was pasted verbatim and
+// produced invalid LogsQL like `field:=~"pattern"` which failed to parse
+// with: `compound token cannot start with "=~"`.
+func TestFilterGeneralString_OperatorMapping(t *testing.T) {
+	f := func(input, wantSubstr string) {
+		t.Helper()
+		lex := newLexer(input, 0)
+		q, err := parseQuery(lex)
+		if err != nil {
+			t.Fatalf("parse %q: %v", input, err)
+		}
+		got := q.String()
+		if !strings.Contains(got, wantSubstr) {
+			t.Fatalf("query %q\n  produced: %s\n  want substring: %s", input, got, wantSubstr)
+		}
+		if strings.Contains(got, ":=~") {
+			t.Fatalf("query %q produced invalid LogsQL `:=~`: %s", input, got)
+		}
+	}
+
+	// Regex match operator `=~` must become LogsQL `~` (not `=~`).
+	f(`{resource.host.name =~ "kimi-k2-a.*"}`, `"resource_attr:host.name":~"kimi-k2-a.*"`)
+
+	// Other operators are passed through unchanged.
+	f(`{resource.service.name = "kimi"}`, `"resource_attr:service.name":=kimi`)
+	f(`{span.http.status_code != 200}`, `"span_attr:http.status_code":!=200`)
+	f(`{span.http.status_code > 400}`, `"span_attr:http.status_code":>400`)
+
+	// Realistic multi-condition query that previously failed.
+	f(`{span.rpc.method = "App" && span.rpc.system = "connect_rpc" && resource.service.name = "kimi" && resource.host.name =~ "kimi-k2-a.*"}`,
+		`"resource_attr:host.name":~"kimi-k2-a.*"`)
 }
 
 func TestGetTraceDurationFilters(t *testing.T) {


### PR DESCRIPTION

### Describe Your Changes

TraceQL queries using =~ (regex match) produced invalid LogsQL like
  `field:=~pattern`
which failed to parse with:
  compound token cannot start with `=~`; put it into quotes if needed

LogsQL uses `~` (not `=~`) for regex matching. filterCommon.String() now maps TraceQL operators to their LogsQL equivalents via a helper.

Adds TestFilterGeneralString_OperatorMapping to cover the realistic multi-condition query that previously failed:
  `{span.rpc.method = "x" && resource.host.name =~ "pod-.*"}`
### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps TraceQL `=~` to LogsQL `~` when composing filters, fixing invalid output like `field:=~"pattern"` that caused LogsQL parse errors.

- **Bug Fixes**
  - Added operator mapping in `filterCommon.String()` via a small helper.
  - Introduced `TestFilterGeneralString_OperatorMapping`, including a realistic multi-condition case and checks that other operators pass through unchanged.

<sup>Written for commit 35f2ab96ab1f1e6678a7c5226357db303cd39dfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

