### PR TITLE
minor improvement for VictoriaTraces doc

### DIFF
--- a/docs/victoriatraces/keyConcepts.md
+++ b/docs/victoriatraces/keyConcepts.md
@@ -161,7 +161,7 @@ There are some special mappings when transforming a trace span into VictoriaTrac
 
 1. Empty attribute values in trace spans are replaced with `-`.
 2. Resource, scope and span attributes are stored with corresponding prefixes `resource_attr`, `scope_attr` and `span_attr:` accordingly.
-3. For some attributes within a list (event list, link list in span), a corresponding prefix and index (such as `event:0:` and `event:0:event_attr:`) is added.
+3. For some attributes within a list (event list, link list in span), a corresponding prefix and index suffix (such as `event:<event_field>:0` and `event:event_attr:<event_attribute_name>:0`) is added.
 4. The `duration` field does not exist in the OTLP request, but for query efficiency, it's calculated during ingestion and stored as a separated field.
 
 VictoriaTraces automatically indexes all the fields for ingested trace spans.


### PR DESCRIPTION
### Describe Your Changes

It's time to provide some love to the documentation, as some of the implementation has changed since `v0.1.0`.

- correct the field name format for span event and span link.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VictoriaTraces docs to show the correct field naming for span events and links by using an index suffix. Examples now use `event:<event_field>:0` and `event:event_attr:<event_attribute_name>:0` to avoid confusion when querying or mapping fields.

<sup>Written for commit 4104332920817e1f4ce61984ab6cd3c5ae6daf31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

