### PR TITLE
fix(tempo): map status_code to ok/error/unset for tag values API

### DIFF
--- a/app/vtselect/traces/tempo/tempo.go
+++ b/app/vtselect/traces/tempo/tempo.go
@@ -368,7 +368,20 @@ func searchTagValues(ctx context.Context, cp *tracecommon.CommonParams, traceQLS
 	q.AddTimeFilter(start, end)
 	q.AddPipeOffsetLimit(0, uint64(limit))
 
-	return singleFieldQueryHelper(ctx, q, cp, limit)
+	values, err := singleFieldQueryHelper(ctx, q, cp, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map raw OTLP status_code integers (0=unset, 1=ok, 2=error) to the
+	// lowercase string names that Tempo returns from this endpoint, so the
+	// Grafana Tempo datasource displays "ok"/"error"/"unset" instead of 0/1/2.
+	if tagName == otelpb.StatusCodeField {
+		for i, v := range values {
+			values[i] = traceql.StatusCodeToName(v)
+		}
+	}
+	return values, nil
 }
 
 // singleFieldQueryHelper execute queries which contains only a single field in response, and return as []string.

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): return Tempo-compatible string values (`unset`, `ok`, `error`) instead of raw OTLP integers (`0`, `1`, `2`) from the `/api/v2/search/tag/status/values` endpoint, so the Grafana Tempo datasource displays the correct options in the `status` dropdown.
+
 ## [v0.9.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.0)
 
 Released at 2026-05-20

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,7 +12,7 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
-* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): return Tempo-compatible string values (`unset`, `ok`, `error`) instead of raw OTLP integers (`0`, `1`, `2`) from the `/api/v2/search/tag/status/values` endpoint, so the Grafana Tempo datasource displays the correct options in the `status` dropdown.
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): return span status in string (`unset`, `ok`, `error`) instead of integers (`0`, `1`, `2`) in Tempo `/api/v2/search/tag/status/values` endpoint. Thank @vshulakov-sh for [the pull request #155](https://github.com/VictoriaMetrics/VictoriaTraces/pull/155).
 
 ## [v0.9.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.0)
 


### PR DESCRIPTION
### Describe Your Changes

The Tempo `/api/v2/search/tag/status/values` endpoint currently returns the raw OTLP `status_code` integers (`0`, `1`, `2`) that are stored on disk. As a result, the Grafana Tempo datasource shows numbers in the `status` filter dropdown instead of the expected `unset` / `ok` / `error` options, and queries like `{status = error}` cannot be composed from the UI.

This change maps the integers to Tempo's lowercase enum names in the response, via the existing `traceql.StatusCodeToName` helper. The filter side (`{status = error}` ↦ `status_code:=2`) already maps names back to integers, so round-tripping works.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Tempo tag values endpoint to return "unset", "ok", and "error" instead of raw OTLP integers. This makes the Grafana Tempo datasource show correct status options and enables composing queries like `{status = error}` from the UI.

- **Bug Fixes**
  - Map `status_code` 0/1/2 to `unset`/`ok`/`error` in `/api/v2/search/tag/status/values` via `traceql.StatusCodeToName`; preserves `{status = error}` ↔ `status_code:=2`.
  - Update changelog to note the status values fix.

<sup>Written for commit f277a2d5b96c44fc592a3b036b09626fb0f6e9a5. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaTraces/pull/155?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

