### PR TITLE
security: upgrade go version to 1.26.3

### DIFF
--- a/.github/workflows/codeql-analysis-go.yml
+++ b/.github/workflows/codeql-analysis-go.yml
@@ -3,13 +3,11 @@ name: 'CodeQL Go'
 on:
   push:
     branches:
-      - cluster
       - master
     paths:
       - '**.go'
   pull_request:
     branches:
-      - cluster
       - master
     paths:
       - '**.go'
@@ -36,7 +34,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           cache: false
-          go-version: stable
+          go-version-file: 'go.mod'
 
       - name: Cache Go artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -46,17 +44,17 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-artifacts-${{ runner.os }}-codeql-analyze-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', 'Makefile', 'app/**/Makefile') }}
-          restore-keys: go-artifacts-${{ runner.os }}-codeql-analyze-
+          restore-keys: go-artifacts-${{ runner.os }}-codeql-analyze-${{ steps.go.outputs.go-version }}-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           category: 'language:go'

--- a/app/vmui/Dockerfile-web
+++ b/app/vmui/Dockerfile-web
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS build-web-stage
+FROM golang:1.26.3 AS build-web-stage
 COPY build /build
 
 WORKDIR /build
@@ -6,7 +6,7 @@ COPY web/ /build/
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o web-amd64 github.com/VictoriMetrics/vmui/ && \
     GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o web-windows github.com/VictoriMetrics/vmui/
 
-FROM alpine:3.22.1
+FROM alpine:3.23.4
 USER root
 
 COPY --from=build-web-stage /build/web-amd64 /app/web

--- a/deployment/docker/Makefile
+++ b/deployment/docker/Makefile
@@ -6,7 +6,7 @@ DOCKER_NAMESPACE ?= victoriametrics
 ROOT_IMAGE ?= alpine:3.23.4
 CERTS_IMAGE := alpine:3.23.4
 
-GO_BUILDER_IMAGE := golang:1.26.2
+GO_BUILDER_IMAGE := golang:1.26.3
 
 BUILDER_IMAGE := local/builder:2.0.0-$(shell echo $(GO_BUILDER_IMAGE) | tr :/ __)-1
 BASE_IMAGE := local/base:1.1.4-$(shell echo $(ROOT_IMAGE) | tr :/ __)-$(shell echo $(CERTS_IMAGE) | tr :/ __)

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -11,6 +11,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 * [How to build single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/#how-to-build-from-sources)
 
 ## tip
+                                                                                                                              
+* SECURITY: upgrade Go builder from Go1.26.2 to Go1.26.3. See the list of issues addressed in [Go1.26.3](https://github.com/golang/go/issues?q=milestone%3AGo1.26.3+label%3ACherryPickApproved).
 
 * FEATURE: [logstorage](https://docs.victoriametrics.com/victorialogs/): upgrade VictoriaLogs dependency from [v1.47.0 to v1.50.0](https://github.com/VictoriaMetrics/VictoriaLogs/compare/v1.47.0...v1.50.0).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VictoriaMetrics/VictoriaTraces
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/VictoriaMetrics/VictoriaLogs v1.121.1-0.20260414190124-77df0c04d532 // v1.50.0


### PR DESCRIPTION
### Describe Your Changes

upgrade go version to 1.26.3

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Go toolchain to 1.26.3 across builds and CI to pick up security fixes and keep tooling consistent. Also refresh Docker and CodeQL configs to align with the new Go version.

- **Dependencies**
  - Set `go 1.26.3` in `go.mod` and use `golang:1.26.3` in build images (`deployment/docker/Makefile`, `app/vmui/Dockerfile-web`).
  - Bump vmui base image to `alpine:3.23.4`.
  - Make CodeQL use Go from `go.mod` via `actions/setup-go` and update `github/codeql-action` to v4.35.3.
  - Narrow cache keys to include the resolved Go version; remove `cluster` branch triggers.
  - Add SECURITY note to the changelog linking to Go 1.26.3 fixes.

<sup>Written for commit 86d73ccdb26541299658512aa189eb0873f34946. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaTraces/pull/160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

