### PR TITLE
Docs: Fix broken anchors in troubleshooting page

### DIFF
--- a/docs/victoriatraces/troubleshooting.md
+++ b/docs/victoriatraces/troubleshooting.md
@@ -16,7 +16,6 @@ aliases:
 This document contains troubleshooting guides for most common issues when working with VictoriaTraces:
 
 - [Data ingestion](#data-ingestion)
-- [Querying](#querying)
 
 ## Data ingestion
 
@@ -28,7 +27,7 @@ curl http://<victoria-traces>:10428/select/logsql/query -d 'query=*' | head
 
 This command selects all the data ingested into VictoriaTraces via [HTTP query API](https://docs.victoriametrics.com/victoriatraces/querying/#http-api)
 using [any value filter](https://docs.victoriametrics.com/victorialogs/logsql/#any-value-filter), while `head` cancels query execution after reading the first 10 trace spans.
-See [these docs](https://docs.victoriametrics.com/victoriatraces/querying/#command-line) for more details on how `head` integrates with VictoriaTraces.
+See [these docs](https://docs.victoriametrics.com/victoriatraces/querying/#querying-traces) for more details on how `head` integrates with VictoriaTraces.
 
 The response by default contains all the [trace span fields](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#data-model).
 See [how to query specific fields](https://docs.victoriametrics.com/victorialogs/logsql/#querying-specific-fields).
@@ -40,14 +39,14 @@ VictoriaTraces provides the following command-line flags, which can help debuggi
   This may help debugging [high cardinality issues](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#high-cardinality).
 - `-logIngestedRows` - if this flag is passed to VictoriaTraces, then it traces all the ingested
   [trace span entries](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#data-model).
-  See also `debug` [parameter](#http-parameters).
+
 
 VictoriaTraces exposes various metrics, which may help debugging data ingestion issues:
 
 - `vt_rows_ingested_total` - the number of ingested [trace span entries](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#data-model)
   since the last VictoriaTraces restart. If this number increases over time, then trace spans are successfully ingested into VictoriaTraces.
   The ingested trace spans can be inspected in the following ways:
-  - By passing `debug=1` parameter to every request to [data ingestion APIs](#http-apis). The ingested spans aren't stored in VictoriaTraces
+  - By passing `debug=1` parameter to every request to data ingestion APIs. The ingested spans aren't stored in VictoriaTraces
       in this case. Instead, they are logged, so they can be investigated later.
       The `vt_rows_dropped_total` metric is incremented for each logged row.
   - By passing `-logIngestedRows` command-line flag to VictoriaTraces. In this case it traces all the ingested data, so it can be investigated later.
@@ -55,3 +54,7 @@ VictoriaTraces exposes various metrics, which may help debugging data ingestion 
   since the last VictoriaTraces restart. If this metric grows rapidly during extended periods of time, then this may lead
   to [high cardinality issues](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#high-cardinality).
   The newly created trace streams can be inspected in traces by passing `-logNewStreams` command-line flag to VictoriaTraces.
+
+## See also
+
+- [Querying](https://docs.victoriametrics.com/victoriatraces/querying/)

--- a/docs/victoriatraces/troubleshooting.md
+++ b/docs/victoriatraces/troubleshooting.md
@@ -27,7 +27,7 @@ curl http://<victoria-traces>:10428/select/logsql/query -d 'query=*' | head
 
 This command selects all the data ingested into VictoriaTraces via [HTTP query API](https://docs.victoriametrics.com/victoriatraces/querying/#http-api)
 using [any value filter](https://docs.victoriametrics.com/victorialogs/logsql/#any-value-filter), while `head` cancels query execution after reading the first 10 trace spans.
-See [these docs](https://docs.victoriametrics.com/victoriatraces/querying/#querying-traces) for more details on how `head` integrates with VictoriaTraces.
+See [VictoriaLogs's docs](https://docs.victoriametrics.com/victorialogs/querying/#command-line) for more details on how `head` integrates with VictoriaTraces as well.
 
 The response by default contains all the [trace span fields](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#data-model).
 See [how to query specific fields](https://docs.victoriametrics.com/victorialogs/logsql/#querying-specific-fields).


### PR DESCRIPTION
### Describe Your Changes

It seems that the troubleshooting page had some content removed. 

This PR removes the invalid anchors from the content that no longer exists in the troubleshooting.md page.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
