### PR TITLE
fix(tempo): fix two wrong error messages in parseTempoAPIParam and summarySearchTracesResult

### DIFF
--- a/app/vtselect/traces/tempo/tempo.go
+++ b/app/vtselect/traces/tempo/tempo.go
@@ -481,7 +481,7 @@ func summarySearchTracesResult(ctx context.Context, rows []*tracecommon.Row, lim
 		}
 
 		if traceID == "" {
-			return nil, fmt.Errorf("trace ID found for a span %v", row)
+			return nil, fmt.Errorf("trace ID not found for a span %v", row)
 		}
 
 		// get the summary for this trace
@@ -549,7 +549,7 @@ func parseTempoAPIParam(_ context.Context, r *http.Request, allowDefaultTime boo
 	if end != "" {
 		ts, ok := timeutil.TryParseUnixTimestamp(end)
 		if !ok {
-			return nil, fmt.Errorf("cannot parse end timestamp: %s", start)
+			return nil, fmt.Errorf("cannot parse end timestamp: %s", end)
 		}
 		p.end = time.Unix(ts/1e9, 0)
 	}


### PR DESCRIPTION
Two small copy-paste bugs in `app/vtselect/traces/tempo/tempo.go`.

**Bug 1** - wrong variable in error message (`parseTempoAPIParam`):

When the `end` query param can't be parsed, the error message prints the value of `start` instead of `end`:

```go
// before
return nil, fmt.Errorf("cannot parse end timestamp: %s", start)
// after
return nil, fmt.Errorf("cannot parse end timestamp: %s", end)
```

Reproduce: `GET /select/tempo/api/search?start=1748000000&end=notadate`
Error was: `cannot parse end timestamp: 1748000000` (showing start value, not the bad input)

**Bug 2** - missing "not" in error message (`summarySearchTracesResult`):

```go
// before
return nil, fmt.Errorf("trace ID found for a span %v", row)
// after
return nil, fmt.Errorf("trace ID not found for a span %v", row)
```

The condition is `if traceID == ""`, so the span has no trace ID - the message said "found" when it meant "not found".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two error messages in Tempo to improve debugging. We now report the correct end query value on parse failure and correctly state when a span has no trace ID.

- **Bug Fixes**
  - `parseTempoAPIParam`: print `end` in "cannot parse end timestamp" instead of `start`.
  - `summarySearchTracesResult`: say "trace ID not found" when `traceID` is empty.

<sup>Written for commit 0c83b6dd7ceed49823f4455f256e36c7e81ba00a. Summary will update on new commits. <a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaTraces/pull/166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

