### PR TITLE
fix(vtinsert): gRPC partial_success always set on successful export, plus minor message fixes

### DIFF
--- a/app/vtinsert/main.go
+++ b/app/vtinsert/main.go
@@ -124,7 +124,7 @@ func initGRPCServer() {
 		}
 	}
 
-	logger.Infof("starting OTLP gPRC server at %q...", *otlpGRPCListenAddr)
+	logger.Infof("starting OTLP gRPC server at %q...", *otlpGRPCListenAddr)
 	go http2server.Serve(
 		*otlpGRPCListenAddr,
 		otlpGRPCRequestHandler,
@@ -134,9 +134,9 @@ func initGRPCServer() {
 
 func stopGRPCServer() {
 	startTime := time.Now()
-	logger.Infof("gracefully shutting down the OTLP gPRC server at %q...", *otlpGRPCListenAddr)
+	logger.Infof("gracefully shutting down the OTLP gRPC server at %q...", *otlpGRPCListenAddr)
 	if err := http2server.Stop([]string{*otlpGRPCListenAddr}); err != nil {
 		logger.Fatalf("cannot stop the OTLP gRPC server: %s", err)
 	}
-	logger.Infof("successfully shut down the OTLP gPRC in %.3f seconds", time.Since(startTime).Seconds())
+	logger.Infof("successfully shut down the OTLP gRPC in %.3f seconds", time.Since(startTime).Seconds())
 }

--- a/app/vtinsert/opentelemetry/otlpgrpc.go
+++ b/app/vtinsert/opentelemetry/otlpgrpc.go
@@ -119,7 +119,7 @@ func writeExportTraceServiceResponse(w http.ResponseWriter, rejectedSpans int64,
 	// The server MUST leave the partial_success field unset in case of a successful response.
 	// https://opentelemetry.io/docs/specs/otlp/#full-success
 	resp := &otelpb.ExportTraceServiceResponse{}
-	if rejectedSpans != 0 || errorMessage == "" {
+	if rejectedSpans != 0 || errorMessage != "" {
 		resp.ExportTracePartialSuccess = &otelpb.ExportTracePartialSuccess{
 			RejectedSpans: rejectedSpans,
 			ErrorMessage:  errorMessage,

--- a/app/vtinsert/opentelemetry/otlphttp.go
+++ b/app/vtinsert/opentelemetry/otlphttp.go
@@ -129,7 +129,7 @@ func handleJSONRequest(r *http.Request, w http.ResponseWriter) {
 		tsp := cp.NewTraceProcessor("opentelemetry_traces_otlphttp_json", false)
 		if callbackErr = req.UnmarshalJSONCustom(data); callbackErr != nil {
 			errorsJSONTotal.Inc()
-			return fmt.Errorf("cannot unmarshal request from %d protobuf bytes: %w", len(data), callbackErr)
+			return fmt.Errorf("cannot unmarshal request from %d json bytes: %w", len(data), callbackErr)
 		}
 		callbackErr = pushExportTraceServiceRequest(&req, tsp)
 		tsp.MustClose()

--- a/app/vtstorage/main.go
+++ b/app/vtstorage/main.go
@@ -129,7 +129,7 @@ func initLocalStorage() {
 		logger.Fatalf("-retention.maxDiskSpaceUsageBytes and -retention.maxDiskUsagePercent cannot be set simultaneously")
 	}
 	if *maxDiskUsagePercent < 0 || *maxDiskUsagePercent > 100 {
-		logger.Fatalf("-retention.maxDiskUsagePercent must be between 1 and 100; got %d", *maxDiskUsagePercent)
+		logger.Fatalf("-retention.maxDiskUsagePercent must be between 0 and 100; got %d", *maxDiskUsagePercent)
 	}
 	cfg := &logstorage.StorageConfig{
 		Retention:              retentionPeriod.Duration(),

--- a/app/vtstorage/main.go
+++ b/app/vtstorage/main.go
@@ -129,7 +129,7 @@ func initLocalStorage() {
 		logger.Fatalf("-retention.maxDiskSpaceUsageBytes and -retention.maxDiskUsagePercent cannot be set simultaneously")
 	}
 	if *maxDiskUsagePercent < 0 || *maxDiskUsagePercent > 100 {
-		logger.Fatalf("-retention.maxDiskUsagePercent must be between 0 and 100; got %d", *maxDiskUsagePercent)
+		logger.Fatalf("-retention.maxDiskUsagePercent must be between 1 and 100; got %d", *maxDiskUsagePercent)
 	}
 	cfg := &logstorage.StorageConfig{
 		Retention:              retentionPeriod.Duration(),

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -14,6 +14,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 * FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtstorage in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): expose filesystem type for storage paths via the `vm_fs_info` metric. This helps identify filesystem-specific issues during troubleshooting. See [#164](https://github.com/VictoriaMetrics/VictoriaTraces/issues/164) for details.
 
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtinsert in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): response empty partial success correctly when error message for OTLP ingestion is empty. Thank @immanuwell for [the pull request #170](https://github.com/VictoriaMetrics/VictoriaTraces/pull/170).
+
 ## [v0.9.2](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.2)
 
 Released at 2026-06-01


### PR DESCRIPTION
### Describe Your Changes

Four fixes in the OTLP insert path.

Main one: `otlpgrpc.go:122` has the `partial_success` guard condition backwards. `errorMessage == ""` should be `errorMessage != ""`. 
So on every clean gRPC export `ExportTracePartialSuccess` always gets populated, which is straight up violating the spec. 
The comment literally sitting two lines above says "The server MUST leave the partial_success field unset in case of a successful response."

To repro: hit the gRPC endpoint with any valid trace payload, decode the raw response proto - `partial_success` is always set, even on a fully clean export.

Also fixed:
- `otlphttp.go:132`: error msg inside `handleJSONRequest` says "protobuf bytes" when handling json. copy-paste leftover
- `vtinsert/main.go` lines 127, 137, 141: "gPRC" typo (line 139 in the same func already has it right)
- `vtstorage/main.go:132`: error says "between 1 and 100" but the validation condition allows 0 (`< 0 || > 100`)

### Checklist

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OTLP gRPC partial_success so it’s unset on full success per spec. Also tidies error/log messages and adds a changelog note.

- **Bug Fixes**
  - Set ExportTracePartialSuccess only when spans are rejected or an error exists; was always set on success.
  - JSON handler error now says “json bytes” instead of “protobuf bytes.”
  - Corrected “gPRC” → “gRPC” in OTLP gRPC server logs.

<sup>Written for commit b6deeefa737f804d94a87614d64b1f66c35cb13f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaTraces/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



