### PR TITLE
bugfix: exclude unnecessary streams during trace search

### DIFF
--- a/app/vtselect/traces/query/query.go
+++ b/app/vtselect/traces/query/query.go
@@ -37,8 +37,8 @@ type TraceQueryParam struct {
 func GetServiceNameList(ctx context.Context, cp *tracecommon.CommonParams) ([]string, error) {
 	currentTime := time.Now()
 
-	// query: _time:[start, end] *
-	qStr := "*"
+	// query: _time:[start, end] {resource_attr:service.name!=""}
+	qStr := `{resource_attr:service.name!=""}`
 	q, err := logstorage.ParseQueryAtTimestamp(qStr, currentTime.UnixNano())
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse query [%s]: %s", qStr, err)
@@ -98,7 +98,7 @@ func GetTrace(ctx context.Context, cp *tracecommon.CommonParams, traceID string)
 	currentTime := time.Now()
 
 	// possible partition
-	// query: {trace_id_idx="xx"} AND trace_id:traceID
+	// query: {trace_id_idx_stream="xx"} AND trace_id_idx:traceID
 	qStr := fmt.Sprintf(
 		`{%s="%d"} AND %s:=%q | stats min(_time) _time, min(%s) %s, max(%s) %s`,
 		otelpb.TraceIDIndexStreamName,
@@ -139,7 +139,7 @@ func GetTrace(ctx context.Context, cp *tracecommon.CommonParams, traceID string)
 func GetTraceList(ctx context.Context, cp *tracecommon.CommonParams, param *TraceQueryParam) ([]string, []*tracecommon.Row, error) {
 	currentTime := time.Now()
 
-	// query 1: * AND filter_conditions | last 1 by (_time) partition by (trace_id) | fields _time, trace_id | sort by (_time) desc
+	// query 1: {resource_attr:service.name!=""} AND filter_conditions | last 1 by (_time) partition by (trace_id) | fields _time, trace_id | sort by (_time) desc
 	traceIDs, startTime, err := getTraceIDList(ctx, cp, param)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get trace id error: %w", err)
@@ -219,8 +219,8 @@ func GetTraceList(ctx context.Context, cp *tracecommon.CommonParams, param *Trac
 // It also returns the earliest start time of these traces, to help reducing the time range for spans search.
 func getTraceIDList(ctx context.Context, cp *tracecommon.CommonParams, param *TraceQueryParam) ([]string, time.Time, error) {
 	currentTime := time.Now()
-	// query: * AND <filter> | last 1 by (_time) partition by (trace_id) | fields _time, trace_id | sort by (_time) desc
-	qStr := "* "
+	// query: {resource_attr:service.name!=""} AND <filter> | last 1 by (_time) partition by (trace_id) | fields _time, trace_id | sort by (_time) desc
+	qStr := `{resource_attr:service.name!=""} `
 	if param.ServiceName != "" {
 		qStr += fmt.Sprintf("AND _stream:{"+otelpb.ResourceAttrServiceName+"=%q} ", param.ServiceName)
 	}

--- a/app/vtselect/traces/tempo/query.go
+++ b/app/vtselect/traces/tempo/query.go
@@ -44,7 +44,7 @@ import (
 func GetTraceList(ctx context.Context, cp *tracecommon.CommonParams, filterQuery *traceql.Query, start, end time.Time, limit int64) ([]string, []*tracecommon.Row, error) {
 	currentTime := time.Now()
 
-	// query 1: * AND filter_conditions | last 1 by (_time) partition by (trace_id) | fields _time, trace_id | sort by (_time) desc
+	// query 1: {resource_attr:service.name!=""} AND filter_conditions | last 1 by (_time) partition by (trace_id) | fields _time, trace_id | sort by (_time) desc
 	traceIDs, startTime, err := getTraceIDList(ctx, cp, filterQuery, start, end, limit)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get trace id error: %w", err)
@@ -121,7 +121,7 @@ func GetTraceList(ctx context.Context, cp *tracecommon.CommonParams, filterQuery
 }
 
 func getTraceIDList(ctx context.Context, cp *tracecommon.CommonParams, filterQuery *traceql.Query, start, end time.Time, limit int64) ([]string, time.Time, error) {
-	qStr := `{trace_id_idx_stream=""} AND ` + filterQuery.String() + ` | last 1 by (_time) partition by (` + otelpb.TraceIDField + ") | fields _time, " + otelpb.TraceIDField + " | sort by (_time) desc"
+	qStr := `{resource_attr:service.name!=""} AND ` + filterQuery.String() + ` | last 1 by (_time) partition by (` + otelpb.TraceIDField + ") | fields _time, " + otelpb.TraceIDField + " | sort by (_time) desc"
 
 	q, err := logstorage.ParseQueryAtTimestamp(qStr, end.UnixNano())
 	if err != nil {

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,12 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+## [v0.9.2](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.2)
+
+Released at 2026-06-01
+
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): exclude unnecessary streams during trace search. These streams caused empty `trace_id` values in subsequent queries and parsing errors.
+
 ## [v0.9.1](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.1)
 
 Released at 2026-06-01


### PR DESCRIPTION
### Describe Your Changes

exclude unnecessary streams during trace search. These streams caused empty `trace_id` values in subsequent queries and parsing errors.

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude non-service streams during trace search to stop empty trace_id results and parsing errors. This applies to both standard and Tempo query paths and updates the changelog.

- **Bug Fixes**
  - Add filter resource_attr:service.name!="" to service name and trace list queries, including Tempo.
  - Replace the old trace stream filter with the service-name filter and update the v0.9.2 changelog entry.

<sup>Written for commit 673547d05b4fed7604ec1906d51df199433147d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/VictoriaTraces/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

