### PR TITLE
Docs: Add `docs-check-links` target to find broken links

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -56,6 +56,17 @@ docs-images-to-webp: docs-image
 				-regex ".*\.\(png\|jpg\|jpeg\)" \
 				-exec sh -c 'cwebp -preset drawing -m 6 -o $$(echo {} | cut -f-1 -d.).webp {} && rm -rf {}' {} \;
 
+docs-check-links: docs-image
+	rm -rf $(PWD)/docs/public
+	docker run \
+		--rm \
+		--platform $(DOCKER_PLATFORM) \
+		-v $(PWD)/docs/victoriatraces:/opt/docs/content/victoriatraces \
+		-v $(PWD)/docs/public:/opt/docs/public \
+		--entrypoint /bin/sh \
+		vmdocs-docker-package \
+			-c "yarn install && hugo --minify && yarn run check-links"
+
 docs-update-victoria-traces-flags:
 	# ---- victoria-traces
 	#(cd /tmp/vt-enterprise && make victoria-traces)


### PR DESCRIPTION
### Describe Your Changes

We have a check-links target in the vmdocs repository. This is a good start but it only detects broken links after changes in docs are merged into master in this repository.

It would be nice to have a way to check the documentation in this repository (before creating a PR for instance). This PR introduces a docs-check-links target to the docs/Makefile. This lets us see if we have any new broken links in the current branch/PR before merging into main.

We've already implemented this on VictoriaMetrics here: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11121
### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
