### PR TITLE
vtselect: support span kind in string (internal/client/server/...) in Tempo API and TraceQL

### DIFF
--- a/app/vtselect/traces/tempo/metrics_handler.go
+++ b/app/vtselect/traces/tempo/metrics_handler.go
@@ -448,9 +448,13 @@ func buildCompareSeries(results []compareAttrResult, topN int, endTimestampMs in
 		traceQLName := traceql.VTFieldToTraceQL(ar.attrName)
 
 		// Reverse-map known numeric values to human-readable names.
-		if ar.attrName == otelpb.StatusCodeField {
+		switch ar.attrName {
+		case otelpb.StatusCodeField:
 			ar.baseline = remapStatusValues(ar.baseline)
 			ar.selection = remapStatusValues(ar.selection)
+		case otelpb.KindField:
+			ar.baseline = remapSpanKindValues(ar.baseline)
+			ar.selection = remapSpanKindValues(ar.selection)
 		}
 
 		// Rank values by total count (baseline + selection combined).
@@ -501,6 +505,14 @@ func remapStatusValues(counts map[string]uint64) map[string]uint64 {
 	result := make(map[string]uint64, len(counts))
 	for v, c := range counts {
 		result[traceql.StatusCodeToName(v)] = c
+	}
+	return result
+}
+
+func remapSpanKindValues(counts map[string]uint64) map[string]uint64 {
+	result := make(map[string]uint64, len(counts))
+	for v, c := range counts {
+		result[traceql.SpanKindToName(v)] = c
 	}
 	return result
 }

--- a/app/vtselect/traces/tempo/tempo.go
+++ b/app/vtselect/traces/tempo/tempo.go
@@ -506,12 +506,17 @@ func searchTagValues(ctx context.Context, cp *tracecommon.CommonParams, traceQLS
 		return nil, err
 	}
 
-	// Map raw OTLP status_code integers (0=unset, 1=ok, 2=error) to the
+	// Map raw OpenTelemetry integers in StatusCode, SpanKind to the
 	// lowercase string names that Tempo returns from this endpoint, so the
-	// Grafana Tempo datasource displays "ok"/"error"/"unset" instead of 0/1/2.
-	if tagName == otelpb.StatusCodeField {
+	// Grafana Tempo datasource displays "ok"/"error"/"unset", "client"/"server"/... instead of ints.
+	switch tagName {
+	case otelpb.StatusCodeField:
 		for i, v := range values {
 			values[i] = traceql.StatusCodeToName(v)
+		}
+	case otelpb.KindField:
+		for i, v := range values {
+			values[i] = traceql.SpanKindToName(v)
 		}
 	}
 	return values, nil

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): return span kinds in strings (`internal`, `client`, `server`, etc.) rather than integers for the Tempo `/api/v2/search/tag/status/values` endpoint; also add support for span kind transformation in TraceQL. Thank @pkieszcz for reporting [the issue #200](https://github.com/VictoriaMetrics/VictoriaTraces/issues/200).
+
 ## [v0.9.4](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.9.4)
 
 Released at 2026-07-03

--- a/lib/traceql/filter_general.go
+++ b/lib/traceql/filter_general.go
@@ -56,7 +56,7 @@ var streamFieldMap = map[string]bool{
 	otelpb.NameField:               true,
 }
 
-// spanKindRegex matches the three TraceQL SpanKind keywords at word
+// spanKindRegex matches the TraceQL SpanKind keywords at word
 // boundaries so they can be rewritten into their numeric OpenTelemetry SpanKind
 // equivalents inside regex patterns on the `kind` field.
 var spanKindRegex = regexp.MustCompile(`(?i)\b(unspecified|internal|server|client|producer|consumer)\b`)

--- a/lib/traceql/filter_general.go
+++ b/lib/traceql/filter_general.go
@@ -8,6 +8,12 @@ import (
 	otelpb "github.com/VictoriaMetrics/VictoriaTraces/lib/protoparser/opentelemetry/pb"
 )
 
+type filterCommon struct {
+	fieldName string
+	op        string
+	value     string
+}
+
 // statusNameRegex matches the three TraceQL status name keywords at word
 // boundaries so they can be rewritten into their numeric OTel StatusCode
 // equivalents inside regex patterns on the `status` field.
@@ -19,13 +25,7 @@ func rewriteStatusNamesInRegex(s string) string {
 	})
 }
 
-type filterCommon struct {
-	fieldName string
-	op        string
-	value     string
-}
-
-// statusValueMap maps TraceQL status names to OTEL StatusCode numeric values.
+// statusValueMap maps TraceQL status names to OpenTelemetry StatusCode numeric values.
 var statusValueMap = map[string]string{
 	"unset": "0",
 	"ok":    "1",
@@ -41,16 +41,55 @@ var statusCodeMap = func() map[string]string {
 	return m
 }()
 
+// StatusCodeToName converts a numeric OpenTelemetry StatusCode ("2") to its TraceQL name ("error").
+// Returns the input unchanged if not a known status code.
+func StatusCodeToName(code string) string {
+	if name, ok := statusCodeMap[code]; ok {
+		return name
+	}
+	return code
+}
+
 // streamFieldMap contains the field names of stream fields defined by VictoriaTraces.
 var streamFieldMap = map[string]bool{
 	otelpb.ResourceAttrServiceName: true,
 	otelpb.NameField:               true,
 }
 
-// StatusCodeToName converts a numeric OTEL StatusCode ("2") to its TraceQL name ("error").
-// Returns the input unchanged if not a known status code.
-func StatusCodeToName(code string) string {
-	if name, ok := statusCodeMap[code]; ok {
+// spanKindRegex matches the three TraceQL SpanKind keywords at word
+// boundaries so they can be rewritten into their numeric OpenTelemetry SpanKind
+// equivalents inside regex patterns on the `kind` field.
+var spanKindRegex = regexp.MustCompile(`(?i)\b(unspecified|internal|server|client|producer|consumer)\b`)
+
+func rewriteSpanKindInRegex(s string) string {
+	return spanKindRegex.ReplaceAllStringFunc(s, func(m string) string {
+		return spanKindValueMap[strings.ToLower(m)]
+	})
+}
+
+// spanKindValueMap maps TraceQL SpanKind to OpenTelemetry SpanKind numeric values.
+var spanKindValueMap = map[string]string{
+	"unspecified": "0",
+	"internal":    "1",
+	"server":      "2",
+	"client":      "3",
+	"producer":    "4",
+	"consumer":    "5",
+}
+
+// spanKindMap is the reverse of spanKindValueMap.
+var spanKindMap = func() map[string]string {
+	m := make(map[string]string, len(spanKindValueMap))
+	for name, code := range spanKindValueMap {
+		m[code] = name
+	}
+	return m
+}()
+
+// SpanKindToName converts a numeric OpenTelemetry SpanKind ("2") to its TraceQL name ("server").
+// Returns the input unchanged if not a known SpanKind.
+func SpanKindToName(code string) string {
+	if name, ok := spanKindMap[code]; ok {
 		return name
 	}
 	return code
@@ -88,9 +127,12 @@ func (fc *filterCommon) String() string {
 	fieldName := fc.tagToVTField()
 	fieldValue := fc.value
 
-	// map status names (error, ok, unset) to numeric OTEL StatusCode values.
 	if fieldName == "status_code" {
+		// map status names (error, ok, unset) to numeric OpenTelemetry StatusCode values.
 		fieldValue = rewriteStatusNamesInRegex(fieldValue)
+	} else if fieldName == "kind" {
+		// map span kind (server, client, producer, consumer...) to numeric OpenTelemetry SpanKind values.
+		fieldValue = rewriteSpanKindInRegex(fieldValue)
 	}
 
 	// translate duration to nanosecond.

--- a/lib/traceql/parser_test.go
+++ b/lib/traceql/parser_test.go
@@ -77,6 +77,8 @@ func TestParseQuery(t *testing.T) {
 	f(`{status = "error"}`, `status_code:=2`)
 	f(`{status = "unset"}`, `status_code:=0`)
 	f(`{resource.service.name = "my_service"}`, `{"resource_attr:service.name"=my_service}`)
+	f(`{kind = "internal"}`, `kind:=1`)
+	f(`{kind = "client"}`, `kind:=3`)
 
 	// span.* attribute regex. The internal field name "span_attr:http.status_code"
 	// contains ':' so quoteFieldNameIfNeeded wraps it in quotes.
@@ -94,6 +96,14 @@ func TestParseQuery(t *testing.T) {
 
 	// status field: case-insensitive name match.
 	f(`{status =~ "OK|Error"}`, `status_code:~"1|2"`)
+
+	// span kind field: name -> code rewrite at word boundaries.
+	f(`{kind =~ "internal|server"}`, `kind:~"1|2"`)
+	f(`{kind =~ "^(consumer|producer)$"}`, `kind:~"^(5|4)$"`)
+	f(`{kind !~ "UNSPECIFIED"}`, `kind:!~"0"`)
+
+	// span kind field: case-insensitive name match.
+	f(`{kind =~ "UNSPECIFIED|Server|consumer"}`, `kind:~"0|2|5"`)
 
 	// Regex match operator `=~` must become LogsQL `~` (not `=~`).
 	f(`{resource.host.name =~ "kimi-k2-a.*"}`, `"resource_attr:host.name":~"kimi-k2-a.*"`)


### PR DESCRIPTION
### Describe Your Changes

fix https://github.com/VictoriaMetrics/VictoriaTraces/pull/200

return span kinds in strings (`internal`, `client`, `server`, etc.) rather than integers for the Tempo `/api/v2/search/tag/status/values` endpoint; also add support for span kind transformation in TraceQL. 


### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
