### PR TITLE
remove unnecessary memory allocation in /tempo/api/search

### DIFF
--- a/app/vtselect/traces/tempo/tempo.go
+++ b/app/vtselect/traces/tempo/tempo.go
@@ -631,16 +631,15 @@ func summarySearchTracesResult(ctx context.Context, rows []*tracecommon.Row, lim
 				}
 			default:
 				// span attributes
-				v := strings.Clone(field.Value)
 				if strings.HasPrefix(field.Name, otelpb.ResourceAttrPrefix) { // resource attributes
 					attributes = append(attributes, attribute{
 						key:  strings.TrimPrefix(field.Name, otelpb.ResourceAttrPrefix),
-						vStr: v,
+						vStr: field.Value,
 					})
 				} else if strings.HasPrefix(field.Name, otelpb.SpanAttrPrefixField) {
 					attributes = append(attributes, attribute{
 						key:  strings.TrimPrefix(field.Name, otelpb.SpanAttrPrefixField),
-						vStr: v,
+						vStr: field.Value,
 					})
 				}
 			}


### PR DESCRIPTION
### Describe Your Changes

There's no need to clone value in `summarySearchTracesResult()`, because we already clone it in https://github.com/VictoriaMetrics/VictoriaTraces/blob/master/app/vtselect/traces/tempo/query.go#L101 And it's safe to have its reference here.

In my dataset, the unnecessary clone will contribute ~5% memory usage.
<img width="729" height="751" alt="image" src="https://github.com/user-attachments/assets/de94f26c-dfaa-4690-9176-590348d95dcb" />



### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
