### PR TITLE
Docs: Fix broken anchors in Querying page (added missing sections)

### DIFF
--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -244,7 +244,12 @@ VictoriaTraces provides the following Tempo HTTP endpoints:
 - `/select/tempo/api/v2/traces/{trace_id}` for fetching a single trace by its ID (v2, similar to v1 but with different data structure).
 - `/select/tempo/api/metrics/query_range` for evaluating a TraceQL metrics query over a time range.
 
-#### Querying Examples
+#### Searching traces
+
+Searching traces with TraceQL is done via the `/select/tempo/api/search` endpoint.
+See the example below for details.
+
+##### Querying Examples
 
 1. Find traces of the `frontend` service with status `error`:
 
@@ -270,6 +275,16 @@ Here's a response example:
 ```json
 {"trace":{"resourceSpans":[{"resource":{"attributes":[{"key":"docker.cli.cobra.command_path","value":{"stringValue":"docker%20compose"}},{"key":"service.name","value":{"stringValue":"frontend-proxy"}}]},"scopeSpans":[{"scope":{"name":"","version":"","attributes":[]},"spans":[{"traceId":"2NjZxtHN+lNE7z1puLWU2A==","spanId":"yuSYZPL61X8=","parentSpanId":"M+KIEWQP/FQ=","name":"router image-provider egress","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1783062881157505553","endTimeUnixNano":"1783062881196836233","attributes":[{"key":"component","value":{"stringValue":"proxy"}},{"key":"http.protocol","value":{"stringValue":"HTTP/1.1"}}],"status":{}}]}]}]},"metrics":{"inspectedBytes":"0"}}
 ```
+
+#### Auto-completion of tags and values
+
+Auto-completion of tag names and values is available via the `/select/tempo/api/v2/search/tags` and `/select/tempo/api/v2/search/tag/{tag}/values` endpoints.
+These are used by the Grafana Traces Drilldown for filtering and exploration.
+
+#### TraceQL metrics
+
+TraceQL metrics enable rate, error, and duration (RED) queries over trace spans.
+They are available via the `/select/tempo/api/metrics/query_range` endpoint.
 
 3. Querying metrics of trace spans
 

--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -244,6 +244,8 @@ VictoriaTraces provides the following Tempo HTTP endpoints:
 - `/select/tempo/api/v2/traces/{trace_id}` for fetching a single trace by its ID (v2, similar to v1 but with different data structure).
 - `/select/tempo/api/metrics/query_range` for evaluating a TraceQL metrics query over a time range.
 
+#### Querying Examples
+
 1. Find traces of the `frontend` service with status `error`:
 
 ```sh

--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -110,7 +110,7 @@ Here's a response example:
         "orders publish",
         "oteldemo.CartService/EmptyCart",
         "oteldemo.CartService/GetCart",
-        "oteldemo.CheckoutService/PlaceOrder",
+        "oteldemo.CheckoutService/PlaceOrder"
     ],
     "errors": null,
     "limit": 0,
@@ -244,13 +244,6 @@ VictoriaTraces provides the following Tempo HTTP endpoints:
 - `/select/tempo/api/v2/traces/{trace_id}` for fetching a single trace by its ID (v2, similar to v1 but with different data structure).
 - `/select/tempo/api/metrics/query_range` for evaluating a TraceQL metrics query over a time range.
 
-#### Searching traces
-
-Searching traces with TraceQL is done via the `/select/tempo/api/search` endpoint.
-See the example below for details.
-
-##### Querying Examples
-
 1. Find traces of the `frontend` service with status `error`:
 
 ```sh
@@ -275,16 +268,6 @@ Here's a response example:
 ```json
 {"trace":{"resourceSpans":[{"resource":{"attributes":[{"key":"docker.cli.cobra.command_path","value":{"stringValue":"docker%20compose"}},{"key":"service.name","value":{"stringValue":"frontend-proxy"}}]},"scopeSpans":[{"scope":{"name":"","version":"","attributes":[]},"spans":[{"traceId":"2NjZxtHN+lNE7z1puLWU2A==","spanId":"yuSYZPL61X8=","parentSpanId":"M+KIEWQP/FQ=","name":"router image-provider egress","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1783062881157505553","endTimeUnixNano":"1783062881196836233","attributes":[{"key":"component","value":{"stringValue":"proxy"}},{"key":"http.protocol","value":{"stringValue":"HTTP/1.1"}}],"status":{}}]}]}]},"metrics":{"inspectedBytes":"0"}}
 ```
-
-#### Auto-completion of tags and values
-
-Auto-completion of tag names and values is available via the `/select/tempo/api/v2/search/tags` and `/select/tempo/api/v2/search/tag/{tag}/values` endpoints.
-These are used by the Grafana Traces Drilldown for filtering and exploration.
-
-#### TraceQL metrics
-
-TraceQL metrics enable rate, error, and duration (RED) queries over trace spans.
-They are available via the `/select/tempo/api/metrics/query_range` endpoint.
 
 3. Querying metrics of trace spans
 

--- a/docs/victoriatraces/querying/grafana.md
+++ b/docs/victoriatraces/querying/grafana.md
@@ -61,7 +61,6 @@ The [Grafana Traces Drilldown](https://grafana.com/docs/grafana-cloud/visualizat
 runs on top of the Tempo datasource configured above. After adding the datasource, navigate to **Explore -> Drilldown -> Traces** (or
 open the standalone Traces Drilldown app) and select your VictoriaTraces Tempo datasource.
 
-Drilldown relies on the [TraceQL metrics](https://docs.victoriametrics.com/victoriatraces/querying/#traceql-metrics) endpoint to
-render its rate, error, and duration panels, and on the [trace search](https://docs.victoriametrics.com/victoriatraces/querying/#searching-traces)
-and [auto-completion](https://docs.victoriametrics.com/victoriatraces/querying/#auto-completion-of-tags-and-values) endpoints for
+Drilldown relies on the TraceQL metrics (`/api/metrics/query_range`) endpoint to
+render its rate, error, and duration panels, and on various [Tempo query endpoints](https://docs.victoriametrics.com/victoriatraces/querying/#tempo-http-api) for
 filtering and exploration. This integration support is experimental, meaning certain panels or TraceQL capabilities may not function identically to native Grafana Tempo.


### PR DESCRIPTION
### Describe Your Changes
The following broken anchors where found in the docs:
  [#] victoriatraces/querying/#traceql-metrics
  [#] victoriatraces/querying/#searching-traces
  [#] victoriatraces/querying/#auto-completion-of-tags-and-values

This PR adds the corresponding sections so they work again

Addresses https://github.com/VictoriaMetrics/vmdocs/issues/221

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
