### PR TITLE
vtinsert: improve rerouting logic as VictoriaLogs

### DIFF
--- a/app/vtstorage/netinsert/netinsert.go
+++ b/app/vtstorage/netinsert/netinsert.go
@@ -390,10 +390,21 @@ func (s *Storage) AddRow(streamHash uint64, r *logstorage.InsertRow) {
 	sn.addRow(r)
 }
 
+// sendInsertRequestToAnyNode controls the rerouting logic when storage node is unavailable.
 func (s *Storage) sendInsertRequestToAnyNode(pendingData *bytesutil.ByteBuffer) bool {
-	startIdx := int(fastrand.Uint32n(uint32(len(s.sns))))
-	for i := range s.sns {
-		idx := (startIdx + i) % len(s.sns)
+	// collect available storage node indexes
+	availableIdx := make([]int, 0, len(s.sns))
+
+	currentTime := fasttime.UnixTimestamp()
+	for idx, sn := range s.sns {
+		if sn.disabledUntil.Load() < currentTime {
+			availableIdx = append(availableIdx, idx)
+		}
+	}
+	// pick a random start position and reroute the data
+	startIdx := int(fastrand.Uint32n(uint32(len(availableIdx))))
+	for i := range availableIdx {
+		idx := availableIdx[(startIdx+i)%len(availableIdx)]
 		sn := s.sns[idx]
 		err := sn.sendInsertRequest(pendingData)
 		if err == nil {

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,7 +12,7 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
-* BUGFIX: [cluster version](https://docs.victoriametrics.com/victoriatraces/cluster/): evenly spread rerouted data across available `vtstorage` nodes. Previously, healthy nodes adjacent to unavailable nodes in the `-storageNode` list could receive much more data, resulting in uneven resource usage. See [this issue #228](https://github.com/VictoriaMetrics/VictoriaLogs/issues/228).
+* BUGFIX: [cluster version](https://docs.victoriametrics.com/victoriatraces/cluster/): evenly spread rerouted data across available `vtstorage` nodes. Previously, healthy nodes adjacent to unavailable nodes in the `-storageNode` list could receive much more data, resulting in uneven resource usage. See [this issue #228](https://github.com/VictoriaMetrics/VictoriaTraces/issues/228).
 
 ## [v0.10.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.10.0)
 

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* BUGFIX: [cluster version](https://docs.victoriametrics.com/victoriatraces/cluster/): evenly spread rerouted data across available `vtstorage` nodes. Previously, healthy nodes adjacent to unavailable nodes in the `-storageNode` list could receive much more data, resulting in uneven resource usage. See [this issue #228](https://github.com/VictoriaMetrics/VictoriaLogs/issues/228).
+
 ## [v0.10.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.10.0)
 
 Released at 2026-07-22


### PR DESCRIPTION
fix #228

evenly spread rerouted data across available `vtstorage` nodes. Previously, healthy nodes adjacent to unavailable nodes in the `-storageNode` list could receive much more data, resulting in uneven resource usage.