### PR TITLE
Docs: Add docs-link-check make target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -56,6 +56,19 @@ docs-images-to-webp: docs-image
 				-regex ".*\.\(png\|jpg\|jpeg\)" \
 				-exec sh -c 'cwebp -preset drawing -m 6 -o $$(echo {} | cut -f-1 -d.).webp {} && rm -rf {}' {} \;
 
+docs-check-links: docs-image
+	rm -rf $(PWD)/docs/public
+	docker run \
+		--rm \
+		--platform $(DOCKER_PLATFORM) \
+		-v $(PWD)/docs/victoriatraces:/opt/docs/content/victoriatraces \
+		-v $(PWD)/docs/public:/opt/docs/public \
+		--entrypoint /bin/sh \
+		vmdocs-docker-package \
+			-c "yarn install && hugo --minify && yarn run check-links" || exit_code=$$?; \
+			rm -rf $(PWD)/docs/public; \
+			exit $$exit_code
+
 docs-update-victoria-traces-flags:
 	# ---- victoria-traces
 	#(cd /tmp/vt-enterprise && make victoria-traces)


### PR DESCRIPTION
### Describe Your Changes

This PR adds a link checker for VictoriaTraces documentation. Just run `make docs-check-links` at the root of the repository to check if your documentation changes generated a broken link.

Right now vmdocs is clean, we've fixed all broken links. We've already implemented this on VictoriaMetrics here: https://github.com/VictoriaMetrics/VictoriaMetrics/pull/11121

I'm also adding the link checking to VictoriaLogs.

If you switch to this branch and run `make docs-check-links` you should get a clean result:

```
$ linkinator .
→ crawling .
✓ Successfully scanned 622 links in 33.481 seconds.
```

I'm adding the link checker to all the sources of documentation to spot issues on docs before their are merged into vmdocs and published.

This PR superseeds https://github.com/VictoriaMetrics/VictoriaTraces/pull/194 which is closed

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
