### PR TITLE
app/vtselect: accept only POST at the delete APIs which remove spans

### DIFF
--- a/app/vtselect/internalselect/internalselect.go
+++ b/app/vtselect/internalselect/internalselect.go
@@ -347,6 +347,16 @@ func processStreamIDsRequest(ctx context.Context, w http.ResponseWriter, r *http
 }
 
 func processDeleteRunTask(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	// This endpoint removes spans, so it must not be reachable via GET.
+	// vtselect always sends POST here, so this rejects nothing legitimate.
+	// See https://github.com/VictoriaMetrics/VictoriaTraces/issues/225
+	if r.Method != http.MethodPost {
+		return &httpserver.ErrorWithStatusCode{
+			Err:        fmt.Errorf("only POST method is allowed for %s; got %s", r.URL.Path, r.Method),
+			StatusCode: http.StatusMethodNotAllowed,
+		}
+	}
+
 	if err := checkProtocolVersion(r, netselect.DeleteRunTaskProtocolVersion); err != nil {
 		return err
 	}

--- a/app/vtselect/internalselect/internalselect_test.go
+++ b/app/vtselect/internalselect/internalselect_test.go
@@ -1,0 +1,63 @@
+package internalselect
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestRequestHandlerDeleteRunTask_MethodNotAllowed checks that the endpoint which removes
+// spans answers 405 to every method except POST.
+//
+// See https://github.com/VictoriaMetrics/VictoriaTraces/issues/225
+func TestRequestHandlerDeleteRunTask_MethodNotAllowed(t *testing.T) {
+	Init()
+	defer Stop()
+
+	f := func(method string) {
+		t.Helper()
+
+		r := httptest.NewRequest(method, "/internal/delete/run_task?filter=*", nil)
+		w := httptest.NewRecorder()
+		RequestHandler(context.Background(), w, r)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("unexpected status code for %s request; got %d; want %d; response: %q",
+				method, w.Code, http.StatusMethodNotAllowed, w.Body.String())
+		}
+	}
+
+	f(http.MethodGet)
+	f(http.MethodHead)
+	f(http.MethodPut)
+	f(http.MethodDelete)
+}
+
+// TestRequestHandlerDeleteRunTask_PostPassesTheMethodCheck checks that a POST request
+// reaches the args parsing, so the method check above rejects nothing which vtselect sends.
+//
+// vtselect always sends POST here, see getResponseBodyForPathAndArgs in app/vtstorage/netselect.
+func TestRequestHandlerDeleteRunTask_PostPassesTheMethodCheck(t *testing.T) {
+	Init()
+	defer Stop()
+
+	args := url.Values{}
+	args.Set("filter", "*")
+	r := httptest.NewRequest(http.MethodPost, "/internal/delete/run_task", strings.NewReader(args.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	// the request carries no version arg, so it must fail on the protocol version check
+	// rather than on the method check.
+	RequestHandler(context.Background(), w, r)
+
+	if w.Code == http.StatusMethodNotAllowed {
+		t.Fatalf("a POST request must not be rejected by the method check; response: %q", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "unexpected protocol version") {
+		t.Fatalf("unexpected response for a POST request; got %q; want the protocol version error", w.Body.String())
+	}
+}

--- a/app/vtselect/logsql.go
+++ b/app/vtselect/logsql.go
@@ -174,6 +174,14 @@ func deleteHandler(w http.ResponseWriter, r *http.Request, path string) {
 	switch path {
 	case "/delete/run_task":
 		deleteRunTaskRequests.Inc()
+		// This endpoint removes spans, so it must not be reachable via GET.
+		// Otherwise a server-side request forgery on any host with access to vtselect
+		// can destroy the stored spans with a plain URL fetch.
+		// See https://github.com/VictoriaMetrics/VictoriaTraces/issues/225
+		if r.Method != http.MethodPost {
+			http.Error(w, fmt.Sprintf("Only POST method is allowed for %s. Got %s.", path, r.Method), http.StatusMethodNotAllowed)
+			return
+		}
 		processDeleteRunTaskRequest(ctx, w, r)
 	case "/delete/stop_task":
 		deleteStopTaskRequests.Inc()

--- a/apptest/tests/delete_method_test.go
+++ b/apptest/tests/delete_method_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	at "github.com/VictoriaMetrics/VictoriaTraces/apptest"
+	otelpb "github.com/VictoriaMetrics/VictoriaTraces/lib/protoparser/opentelemetry/pb"
+)
+
+// TestSingleDeleteRunTaskRequiresPost checks that /delete/run_task drops GET requests
+// and still works over POST.
+//
+// A GET on this path lets a server-side request forgery destroy the stored spans
+// with a plain URL fetch, because no request body is needed.
+// See https://github.com/VictoriaMetrics/VictoriaTraces/issues/225
+func TestSingleDeleteRunTaskRequiresPost(t *testing.T) {
+	os.RemoveAll(t.Name())
+
+	tc := at.NewTestCase(t)
+	defer tc.Stop()
+
+	sut := tc.MustStartVtsingle("vtsingle", []string{
+		"-storageDataPath=" + tc.Dir() + "/vtsingle",
+		"-retentionPeriod=100y",
+		"-delete.enable",
+	})
+
+	serviceName := "testDeleteMethodService"
+	spanTime := time.Now()
+	req := &otelpb.ExportTraceServiceRequest{
+		ResourceSpans: []*otelpb.ResourceSpans{
+			{
+				Resource: otelpb.Resource{
+					Attributes: []*otelpb.KeyValue{
+						{
+							Key:   "service.name",
+							Value: &otelpb.AnyValue{StringValue: &serviceName},
+						},
+					},
+				},
+				ScopeSpans: []*otelpb.ScopeSpans{
+					{
+						Spans: []*otelpb.Span{
+							{
+								TraceID:           "aa5886e99fffef35a847cb2d493fde20",
+								SpanID:            "0123456789abcdef",
+								Name:              "deleteMethodOperation",
+								StartTimeUnixNano: uint64(spanTime.UnixNano()),
+								EndTimeUnixNano:   uint64(spanTime.Add(time.Second).UnixNano()),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	sut.OTLPHTTPExportTraces(t, req, at.QueryOpts{})
+	sut.ForceFlush(t)
+	time.Sleep(2 * time.Second) // index will be created after -insert.traceMaxDuration (2s in integration test)
+
+	tc.Assert(&at.AssertOptions{
+		Msg: "the span was not ingested, so the delete checks below would prove nothing",
+		Got: func() any {
+			return sut.JaegerAPIServices(t, at.QueryOpts{}).Data
+		},
+		Want:    []string{serviceName},
+		Retries: 10,
+		Period:  time.Second,
+	})
+
+	deleteURL := "http://" + sut.HTTPAddr() + "/delete/run_task"
+
+	res, statusCode := tc.Client().Get(t, deleteURL+"?filter=*")
+	if statusCode != 405 {
+		t.Fatalf("unexpected status code for GET %s; got %d, want 405; response: %q", deleteURL, statusCode, res)
+	}
+	if !strings.Contains(res, "Only POST method is allowed") {
+		t.Fatalf("unexpected response body for GET %s; got %q", deleteURL, res)
+	}
+
+	// The rejected GET must not have started a delete task.
+	if got := sut.JaegerAPIServices(t, at.QueryOpts{}).Data; len(got) != 1 || got[0] != serviceName {
+		t.Fatalf("the rejected GET removed data; services after the GET: %v", got)
+	}
+
+	res, statusCode = tc.Client().PostForm(t, deleteURL, url.Values{"filter": []string{"*"}})
+	if statusCode != 200 {
+		t.Fatalf("unexpected status code for POST %s; got %d, want 200; response: %q", deleteURL, statusCode, res)
+	}
+	if !strings.Contains(res, `"task_id"`) {
+		t.Fatalf("missing task_id in response to POST %s; got %q", deleteURL, res)
+	}
+
+	// The delete task runs in the background, so wait for the spans to go away.
+	tc.Assert(&at.AssertOptions{
+		Msg: "the spans were not removed by the accepted POST",
+		Got: func() any {
+			return len(sut.JaegerAPIServices(t, at.QueryOpts{}).Data)
+		},
+		Want:    0,
+		Retries: 30,
+		Period:  time.Second,
+	})
+}

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* SECURITY: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): accept only `POST` requests at `/delete/run_task` and `/internal/delete/run_task`. These endpoints remove spans, and a `GET` request needs no body, so a server-side request forgery on any host with access to VictoriaTraces could destroy the stored spans with a plain URL fetch. Other HTTP methods now return `405 Method Not Allowed`. See [this issue #225](https://github.com/VictoriaMetrics/VictoriaTraces/issues/225).
+
 ## [v0.11.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.11.0)
 
 Released at 2026-08-14


### PR DESCRIPTION
### Describe Your Changes

`/delete/run_task` removes spans and accepts `GET`. The handler reads its filter with
`r.FormValue("filter")` at `app/vtselect/logsql.go:196`, and `FormValue` falls back to
URL query args, so a `GET` does the same work as a `POST`.

A `GET` needs no request body, which puts this within reach of server-side request
forgery. Any host which can be made to fetch a URL can destroy every stored span.

Reproduced on `master` with a local instance started with `-delete.enable`:

```
GET /delete/run_task?filter=*   ->  200  {"task_id":"1786395594614635000"}

services before: {"data":["victim"],"errors": null,"limit": 0,"offset": 0,"total":1}
services after:  {"data":[],"errors": null,"limit": 0,"offset": 0,"total":0}
```

### The change

Two endpoints now answer `405 Method Not Allowed` to anything other than `POST`:

- `/delete/run_task`, in `deleteHandler`
- `/internal/delete/run_task`, in `processDeleteRunTask`

The internal one rejects nothing which works today. `getResponseBodyForPathAndArgs` at
`app/vtstorage/netselect/netselect.go:338` sends every internal request as a `POST`
already, so vtselect keeps working against vtstorage.

`/delete/stop_task` and `/delete/active_tasks` are untouched. Neither removes data, and
the issue asks only for the calls which remove data to be protected. Snapshot deletion
is out of scope for the same reason.

### Tests

`apptest/tests/delete_method_test.go` covers `/delete/run_task` end to end. It ingests
one span, then checks four things: the `GET` returns 405, the data survives the rejected
`GET`, the `POST` returns 200 with a `task_id`, and the spans then disappear.

I ran it against a binary built before the fix and it failed with
`got 200, want 405; response: {"task_id":"..."}`, so it detects the vulnerable build.

`app/vtselect/internalselect/internalselect_test.go` covers `/internal/delete/run_task`
with unit tests, since `apptest` in this repo starts single node only and never reaches
that endpoint. One test checks GET, HEAD, PUT and DELETE all return 405. The other
checks a POST gets past the method check and fails later on the protocol version, which
is what proves the check rejects nothing vtselect sends. Removing the guard makes the
first test fail.

### Compatibility

Anyone calling `/delete/run_task` with a `GET` gets a 405 after this. The endpoint is
not documented, so a `GET` was never a supported way to call it, but the change is
visible.

### VictoriaLogs

VictoriaLogs already rejects a non-`POST` at both endpoints since VictoriaMetrics/VictoriaLogs#1641: `app/vlselect/main.go:415` for `/delete/run_task`, and `internalselect.RequestHandler` for the internal endpoints. This brings VictoriaTraces to the same behaviour.

Fixes https://github.com/VictoriaMetrics/VictoriaTraces/issues/225

