### PR TITLE
vtselect: add TraceQL query profiling API

### DIFF
--- a/app/vtselect/internalselect/internalselect.go
+++ b/app/vtselect/internalselect/internalselect.go
@@ -106,6 +106,7 @@ func parseRequest(r *http.Request) error {
 
 var requestHandlers = map[string]func(ctx context.Context, w http.ResponseWriter, r *http.Request) error{
 	"/internal/select/query":               processQueryRequest,
+	"/internal/select/query_profile":       processQueryProfileRequest,
 	"/internal/select/field_names":         processFieldNamesRequest,
 	"/internal/select/field_values":        processFieldValuesRequest,
 	"/internal/select/stream_field_names":  processStreamFieldNamesRequest,
@@ -120,7 +121,19 @@ var requestHandlers = map[string]func(ctx context.Context, w http.ResponseWriter
 }
 
 func processQueryRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	cp, err := getCommonParams(r, netselect.QueryProtocolVersion)
+	return processQueryRequestExt(ctx, w, r, false)
+}
+
+func processQueryProfileRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	return processQueryRequestExt(ctx, w, r, true)
+}
+
+func processQueryRequestExt(ctx context.Context, w http.ResponseWriter, r *http.Request, profileEnabled bool) error {
+	protocolVersion := netselect.QueryProtocolVersion
+	if profileEnabled {
+		protocolVersion = netselect.QueryProfileProtocolVersion
+	}
+	cp, err := getCommonParams(r, protocolVersion)
 	if err != nil {
 		return err
 	}
@@ -185,23 +198,42 @@ func processQueryRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 	}
 
 	qctx := cp.NewQueryContext(ctx)
+	var profileCollector *logstorage.QueryProfileCollector
+	if profileEnabled {
+		profileCollector = logstorage.NewQueryProfileCollector()
+		qctx.AttachQueryProfile(profileCollector)
+		qctx.SetQueryProfileStage(r.FormValue("profile_stage"), "remote")
+	}
 	defer cp.UpdatePerQueryStatsMetrics()
 
-	if err := vtstorage.RunQuery(qctx, writeBlock); err != nil {
-		if errors.Is(err, vtstoragecommon.ErrOutOfRetention) {
+	runErr := vtstorage.RunQuery(qctx, writeBlock)
+	if errors.Is(runErr, vtstoragecommon.ErrOutOfRetention) {
+		if !profileEnabled {
 			w.Header().Set(vtstoragecommon.OutOfRetentionHeaderName, "true")
 			return nil
 		}
-		return err
+		// Out-of-retention is an expected empty result for trace-ID discovery.
+		// Profile requests still need terminal stats and profile frames.
+		runErr = nil
+	}
+	if runErr != nil && !profileEnabled {
+		return runErr
 	}
 	if errP := errGlobal.Load(); errP != nil {
 		return *errP
 	}
 
-	// Send the remaining data
-	for _, bb := range bufs.All() {
-		if err := sendBuf(bb); err != nil {
-			return err
+	if runErr == nil {
+		// Send the remaining data.
+		for _, bb := range bufs.All() {
+			if err := sendBuf(bb); err != nil {
+				return err
+			}
+		}
+	} else {
+		// Match the normal query endpoint by dropping buffered data after an execution error.
+		for _, bb := range bufs.All() {
+			bb.Reset()
 		}
 	}
 
@@ -209,8 +241,25 @@ func processQueryRequest(ctx context.Context, w http.ResponseWriter, r *http.Req
 	bb := bufs.Get(0)
 	// Write the marker of query stats block.
 	bb.B = append(bb.B, 1)
-	// Marshal the block itself
-	bb.B = marshalQueryStatsBlock(bb.B, qctx)
+	// Marshal the block itself. Keep the normal v5 query stats block byte-compatible.
+	if profileEnabled {
+		bb.B = marshalQueryStatsBlockWithSelectionCounters(bb.B, qctx)
+	} else {
+		bb.B = marshalQueryStatsBlock(bb.B, qctx)
+	}
+	if profileEnabled {
+		// Write the marker and block for the query profile after query stats.
+		bb.B = append(bb.B, 2)
+		snapshot := profileCollector.Snapshot()
+		if runErr != nil {
+			snapshot.Error = runErr.Error()
+		}
+		profileBlock, err := snapshot.CreateDataBlock()
+		if err != nil {
+			return err
+		}
+		bb.B = profileBlock.Marshal(bb.B)
+	}
 	return sendBuf(bb)
 }
 
@@ -550,6 +599,13 @@ func writeValuesWithHits(w http.ResponseWriter, qctx *logstorage.QueryContext, v
 }
 
 func marshalQueryStatsBlock(dst []byte, qctx *logstorage.QueryContext) []byte {
+	queryDurationNsecs := qctx.QueryDurationNsecs()
+	db := qctx.QueryStats.CreateLegacyDataBlock(queryDurationNsecs)
+	dst = db.Marshal(dst)
+	return dst
+}
+
+func marshalQueryStatsBlockWithSelectionCounters(dst []byte, qctx *logstorage.QueryContext) []byte {
 	queryDurationNsecs := qctx.QueryDurationNsecs()
 	db := qctx.QueryStats.CreateDataBlock(queryDurationNsecs)
 	dst = db.Marshal(dst)

--- a/app/vtselect/traces/tempo/profile.go
+++ b/app/vtselect/traces/tempo/profile.go
@@ -1,0 +1,179 @@
+package tempo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver"
+
+	"github.com/VictoriaMetrics/VictoriaTraces/app/vtselect/traces/tracecommon"
+	"github.com/VictoriaMetrics/VictoriaTraces/lib/traceql"
+)
+
+type traceSearchProfileResponse struct {
+	Mode                   string                           `json:"mode"`
+	TraceQL                string                           `json:"traceql"`
+	Start                  time.Time                        `json:"start"`
+	End                    time.Time                        `json:"end"`
+	Limit                  int                              `json:"limit"`
+	PlanningDurationNsecs  int64                            `json:"planning_duration_nsecs"`
+	ExecutionDurationNsecs int64                            `json:"execution_duration_nsecs,omitempty"`
+	Stages                 []traceSearchProfileStage        `json:"stages"`
+	Analysis               *traceSearchAnalysis             `json:"analysis,omitempty"`
+	Execution              *logstorage.QueryProfileSnapshot `json:"execution,omitempty"`
+	Warnings               []string                         `json:"warnings"`
+	Error                  string                           `json:"error,omitempty"`
+}
+
+type traceSearchProfileStage struct {
+	Name          string                     `json:"name"`
+	Operation     string                     `json:"operation"`
+	DependsOn     []string                   `json:"depends_on"`
+	Description   string                     `json:"description"`
+	QueryTemplate string                     `json:"query_template"`
+	Plan          logstorage.QueryStaticPlan `json:"plan"`
+	Dynamic       bool                       `json:"dynamic"`
+}
+
+func processProfileRequest(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	planningStart := time.Now()
+	cp, err := tracecommon.GetCommonParams(r)
+	if err != nil {
+		httpserver.Errorf(w, r, "incorrect query params: %s", err)
+		return
+	}
+	params, err := parseTempoAPIParam(ctx, r, true, *tracecommon.TraceMaxTraces)
+	if err != nil {
+		httpserver.Errorf(w, r, "incorrect query params: %s", err)
+		return
+	}
+	if params.q == "" {
+		params.q = "{}"
+	}
+	mode, err := getProfileMode(r)
+	if err != nil {
+		httpserver.Errorf(w, r, "incorrect profile mode: %s", err)
+		return
+	}
+
+	filterQuery, err := traceql.ParseQuery(params.q)
+	if err != nil {
+		httpserver.Errorf(w, r, "cannot parse TraceQL query: %s", err)
+		return
+	}
+	if filterQuery.HasNonHintPipe() {
+		httpserver.Errorf(w, r, "Tempo trace search profiling accepts filters and display hints only: %s", params.q)
+		return
+	}
+	filterQuery.StripHintPipes()
+
+	stages, err := buildTraceSearchProfileStages(filterQuery, params.start, params.end, params.limit)
+	if err != nil {
+		httpserver.Errorf(w, r, "cannot build query plan: %s", err)
+		return
+	}
+	resp := traceSearchProfileResponse{
+		Mode:                  mode,
+		TraceQL:               params.q,
+		Start:                 params.start,
+		End:                   params.end,
+		Limit:                 params.limit,
+		PlanningDurationNsecs: time.Since(planningStart).Nanoseconds(),
+		Stages:                stages,
+		Warnings: []string{
+			"operator durations are summed wall-clock activity across workers, not CPU time",
+			"exclusive_active_duration_nsecs excludes synchronous downstream forwarding but can include internal waits",
+			"bloom-filter row selectivity and stream-index bytes are omitted because they cannot yet be measured exactly",
+		},
+	}
+
+	statusCode := http.StatusOK
+	if mode == "analyze" {
+		collector := logstorage.NewQueryProfileCollector()
+		cp.ProfileCollector = collector
+		executionStart := time.Now()
+		analysis, runErr := analyzeTraceSearch(ctx, cp, filterQuery, params.start, params.end, params.limit)
+		resp.ExecutionDurationNsecs = time.Since(executionStart).Nanoseconds()
+		resp.Analysis = &analysis
+		snapshot := collector.Snapshot()
+		if runErr != nil {
+			resp.Error = runErr.Error()
+			snapshot.Error = runErr.Error()
+			statusCode = http.StatusInternalServerError
+		}
+		resp.Execution = &snapshot
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		httpserver.Errorf(w, r, "cannot marshal profile response: %s", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(data)
+}
+
+func getProfileMode(r *http.Request) (string, error) {
+	mode := strings.ToLower(r.FormValue("mode"))
+	if mode == "" {
+		analyzeStr := r.FormValue("analyze")
+		if analyzeStr == "" {
+			return "explain", nil
+		}
+		analyze, err := strconv.ParseBool(analyzeStr)
+		if err != nil {
+			return "", fmt.Errorf("cannot parse analyze=%q: %w", analyzeStr, err)
+		}
+		if analyze {
+			return "analyze", nil
+		}
+		return "explain", nil
+	}
+	if mode != "explain" && mode != "analyze" {
+		return "", fmt.Errorf("unsupported mode %q; want explain or analyze", mode)
+	}
+	return mode, nil
+}
+
+func buildTraceSearchProfileStages(filterQuery *traceql.Query, start, end time.Time, limit int) ([]traceSearchProfileStage, error) {
+	traceIDQuery, adjustedEnd, err := newTraceIDListQuery(filterQuery, end, limit)
+	if err != nil {
+		return nil, err
+	}
+	traceIDQuery = traceIDQuery.CloneWithTimeFilter(time.Now().UnixNano(), start.UnixNano(), adjustedEnd.UnixNano())
+	traceIDPlan := logstorage.GetQueryStaticPlan(traceIDQuery)
+
+	spanQuery, err := newTraceSpansQuery(filterQuery, []string{"PROFILE_TRACE_ID"}, time.Now(), start, end)
+	if err != nil {
+		return nil, err
+	}
+	spanPlan := logstorage.GetQueryStaticPlan(spanQuery)
+
+	return []traceSearchProfileStage{
+		{
+			Name:          "trace_id_search",
+			Operation:     "expanding_time_range_scan",
+			DependsOn:     []string{},
+			Description:   "Searches recent windows first, increasing each window by 5x until enough trace IDs are found or the requested start is reached.",
+			QueryTemplate: traceIDQuery.String(),
+			Plan:          traceIDPlan,
+			Dynamic:       true,
+		},
+		{
+			Name:          "span_fetch",
+			Operation:     "dependent_storage_scan",
+			DependsOn:     []string{"trace_id_search"},
+			Description:   "Fetches spans for selected trace IDs and roots; the runtime lower bound comes from the oldest selected trace and is widened by search.traceMaxDurationWindow.",
+			QueryTemplate: spanQuery.String(),
+			Plan:          spanPlan,
+			Dynamic:       true,
+		},
+	}, nil
+}

--- a/app/vtselect/traces/tempo/query.go
+++ b/app/vtselect/traces/tempo/query.go
@@ -53,21 +53,16 @@ func GetTraceList(ctx context.Context, cp *tracecommon.CommonParams, filterQuery
 		return nil, nil, nil
 	}
 
-	// query 2: {resource_attr:service.name!=""} AND (filter_conditions or parent_span_id:="") AND trace_id:in(traceID, traceID, ...)
-	qStr := `{resource_attr:service.name!=""} AND (` + filterQuery.FilterString() + ` OR parent_span_id:="") AND ` + otelpb.TraceIDField + `:in(` + strings.Join(traceIDs, ",") + `)`
-	q, err := logstorage.ParseQueryAtTimestamp(qStr, currentTime.UnixNano())
+	q, err := newTraceSpansQuery(filterQuery, traceIDs, currentTime, startTime, end)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot parse query [%s]: %s", qStr, err)
+		return nil, nil, err
 	}
-
-	// adjust start time and end time with max duration window to make sure all spans are included.
-	q.AddTimeFilter(startTime.Add(-*tracecommon.TraceMaxDurationWindow).UnixNano(), end.Add(*tracecommon.TraceMaxDurationWindow).UnixNano())
 
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	cp.Query = q
-	qctx := cp.NewQueryContext(ctxWithCancel)
+	qctx := cp.NewQueryContextForStage(ctxWithCancel, "span_fetch")
 	defer cp.UpdatePerQueryStatsMetrics()
 
 	// search for trace spans and write to `rows []*Row`
@@ -121,20 +116,12 @@ func GetTraceList(ctx context.Context, cp *tracecommon.CommonParams, filterQuery
 }
 
 func getTraceIDList(ctx context.Context, cp *tracecommon.CommonParams, filterQuery *traceql.Query, start, end time.Time, limit int) ([]string, time.Time, error) {
-	qStr := `{resource_attr:service.name!=""} AND ` + filterQuery.String() + ` | last 1 by (_time) partition by (` + otelpb.TraceIDField + ") | fields _time, " + otelpb.TraceIDField + " | sort by (_time) desc"
-
-	q, err := logstorage.ParseQueryAtTimestamp(qStr, end.UnixNano())
+	q, adjustedEnd, err := newTraceIDListQuery(filterQuery, end, limit)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("cannot parse query [%s]: %s", qStr, err)
+		return nil, time.Time{}, err
 	}
-	q.AddPipeOffsetLimit(0, uint64(limit))
+	end = adjustedEnd
 
-	// adjust the max start time, because fresh traces may not be completed.
-	// they should wait for *latencyOffset before being visible. currently hardcoded as 1m.
-	maxStartTime := time.Now().Add(-*tracecommon.LatencyOffset)
-	if end.After(maxStartTime) {
-		end = maxStartTime
-	}
 	traceIDs, maxStartTime, err := findTraceIDsSplitTimeRange(ctx, q, cp, start, end, limit)
 	if err != nil {
 		return nil, time.Time{}, err
@@ -195,7 +182,7 @@ func findTraceIDsSplitTimeRange(ctx context.Context, q *logstorage.Query, cp *tr
 	maxStartTimeStr := endTime.Format(time.RFC3339)
 
 	cp.Query = q
-	qctx := cp.NewQueryContext(ctx)
+	qctx := cp.NewQueryContextForStage(ctx, "trace_id_search")
 	defer cp.UpdatePerQueryStatsMetrics()
 
 	writeBlock := func(_ uint, db *logstorage.DataBlock) {
@@ -454,4 +441,76 @@ func checkTraceIDList(traceIDList []string) []string {
 		}
 	}
 	return result
+}
+
+func newTraceIDListQuery(filterQuery *traceql.Query, end time.Time, limit int) (*logstorage.Query, time.Time, error) {
+	qStr := `{resource_attr:service.name!=""} AND ` + filterQuery.String() + ` | last 1 by (_time) partition by (` + otelpb.TraceIDField + ") | fields _time, " + otelpb.TraceIDField + " | sort by (_time) desc"
+	q, err := logstorage.ParseQueryAtTimestamp(qStr, end.UnixNano())
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("cannot parse query [%s]: %w", qStr, err)
+	}
+	q.AddPipeOffsetLimit(0, uint64(limit))
+
+	// Fresh traces may still be incomplete, so keep them hidden until latencyOffset has elapsed.
+	maxEnd := time.Now().Add(-*tracecommon.LatencyOffset)
+	if end.After(maxEnd) {
+		end = maxEnd
+	}
+	return q, end, nil
+}
+
+func newTraceSpansQuery(filterQuery *traceql.Query, traceIDs []string, timestamp, start, end time.Time) (*logstorage.Query, error) {
+	qStr := `{resource_attr:service.name!=""} AND (` + filterQuery.FilterString() + ` OR parent_span_id:="") AND ` + otelpb.TraceIDField + `:in(` + strings.Join(traceIDs, ",") + `)`
+	q, err := logstorage.ParseQueryAtTimestamp(qStr, timestamp.UnixNano())
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse query [%s]: %w", qStr, err)
+	}
+	q.AddTimeFilter(start.Add(-*tracecommon.TraceMaxDurationWindow).UnixNano(), end.Add(*tracecommon.TraceMaxDurationWindow).UnixNano())
+	return q, nil
+}
+
+type traceSearchAnalysis struct {
+	TraceIDsFound int    `json:"trace_ids_found"`
+	SpanRowsFound uint64 `json:"span_rows_found"`
+}
+
+// analyzeTraceSearch executes the same two-stage storage workflow as Tempo trace search,
+// but discards span data after counting it.
+func analyzeTraceSearch(ctx context.Context, cp *tracecommon.CommonParams, filterQuery *traceql.Query, start, end time.Time, limit int) (traceSearchAnalysis, error) {
+	traceIDs, spanSearchStart, err := getTraceIDList(ctx, cp, filterQuery, start, end, limit)
+	if cause := context.Cause(ctx); cause != nil {
+		return traceSearchAnalysis{}, cause
+	}
+	if errors.Is(err, vtstoragecommon.ErrOutOfRetention) {
+		return traceSearchAnalysis{}, nil
+	}
+	if err != nil {
+		return traceSearchAnalysis{}, fmt.Errorf("get trace id error: %w", err)
+	}
+	result := traceSearchAnalysis{TraceIDsFound: len(traceIDs)}
+	if len(traceIDs) == 0 {
+		return result, nil
+	}
+
+	q, err := newTraceSpansQuery(filterQuery, traceIDs, time.Now(), spanSearchStart, end)
+	if err != nil {
+		return result, err
+	}
+	cp.Query = q
+	qctx := cp.NewQueryContextForStage(ctx, "span_fetch")
+	defer cp.UpdatePerQueryStatsMetrics()
+
+	var rowsFound atomic.Uint64
+	writeBlock := func(_ uint, db *logstorage.DataBlock) {
+		rowsFound.Add(uint64(db.RowsCount()))
+	}
+	runErr := vtstorage.RunQuery(qctx, writeBlock)
+	if cause := context.Cause(ctx); cause != nil {
+		return result, cause
+	}
+	if runErr != nil {
+		return result, runErr
+	}
+	result.SpanRowsFound = rowsFound.Load()
+	return result, nil
 }

--- a/app/vtselect/traces/tempo/tempo.go
+++ b/app/vtselect/traces/tempo/tempo.go
@@ -34,6 +34,9 @@ var (
 	tempoSearchRequests = metrics.NewCounter(`vt_http_requests_total{path="/select/tempo/api/search"}`)
 	tempoSearchDuration = metrics.NewSummary(`vt_http_request_duration_seconds{path="/select/tempo/api/search"}`)
 
+	tempoProfileRequests = metrics.NewCounter(`vt_http_requests_total{path="/select/tempo/api/profile"}`)
+	tempoProfileDuration = metrics.NewSummary(`vt_http_request_duration_seconds{path="/select/tempo/api/profile"}`)
+
 	tempoQueryRequests = metrics.NewCounter(`vt_http_requests_total{path="/select/tempo/api/traces/*"}`)
 	tempoQueryDuration = metrics.NewSummary(`vt_http_request_duration_seconds{path="/select/tempo/api/traces/*"}`)
 
@@ -65,6 +68,11 @@ func RequestHandler(ctx context.Context, w http.ResponseWriter, r *http.Request)
 		tempoSearchTagValuesRequests.Inc()
 		processSearchTagValuesRequest(ctx, w, r)
 		tempoSearchTagValuesDuration.UpdateDuration(startTime)
+		return true
+	} else if path == "/select/tempo/api/profile" {
+		tempoProfileRequests.Inc()
+		processProfileRequest(ctx, w, r)
+		tempoProfileDuration.UpdateDuration(startTime)
 		return true
 	} else if path == "/select/tempo/api/search" {
 		tempoSearchRequests.Inc()

--- a/app/vtselect/traces/tracecommon/tracecommon.go
+++ b/app/vtselect/traces/tracecommon/tracecommon.go
@@ -59,10 +59,23 @@ type CommonParams struct {
 
 	// qs contains execution statistics for the Query.
 	qs logstorage.QueryStats
+
+	// ProfileCollector optionally receives low-level execution profiles.
+	ProfileCollector *logstorage.QueryProfileCollector
 }
 
 func (cp *CommonParams) NewQueryContext(ctx context.Context) *logstorage.QueryContext {
-	return logstorage.NewQueryContext(ctx, &cp.qs, cp.TenantIDs, cp.Query, cp.AllowPartialResponse, cp.HiddenFieldsFilters)
+	return cp.NewQueryContextForStage(ctx, "query")
+}
+
+// NewQueryContextForStage returns a query context attributed to the given application stage.
+func (cp *CommonParams) NewQueryContextForStage(ctx context.Context, stage string) *logstorage.QueryContext {
+	qctx := logstorage.NewQueryContext(ctx, &cp.qs, cp.TenantIDs, cp.Query, cp.AllowPartialResponse, cp.HiddenFieldsFilters)
+	if cp.ProfileCollector != nil {
+		qctx.AttachQueryProfile(cp.ProfileCollector)
+		qctx.SetQueryProfileStage(stage, "local")
+	}
+	return qctx
 }
 
 func (cp *CommonParams) UpdatePerQueryStatsMetrics() {

--- a/app/vtstorage/netselect/netselect.go
+++ b/app/vtstorage/netselect/netselect.go
@@ -63,6 +63,11 @@ const (
 	// It must be updated every time the protocol changes.
 	QueryProtocolVersion = "v5"
 
+	// QueryProfileProtocolVersion is the version of the protocol used for /internal/select/query_profile HTTP endpoint.
+	//
+	// It must be updated every time the protocol changes.
+	QueryProfileProtocolVersion = "v1"
+
 	// DeleteRunTaskProtocolVersion is the version of the protocol used for /internal/delete/run_task HTTP endpoint.
 	//
 	// It must be updated every time the protocol changes.
@@ -93,6 +98,9 @@ type storageNode struct {
 	// addr is TCP address of the storage node to query
 	addr string
 
+	// index is the coordinator-assigned index in the configured storage node list.
+	index int
+
 	// s is a storage, which holds the given storageNode
 	s *Storage
 
@@ -106,7 +114,7 @@ type storageNode struct {
 	sendErrors *metrics.Counter
 }
 
-func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *storageNode {
+func newStorageNode(s *Storage, index int, addr string, ac *promauth.Config, isTLS bool) *storageNode {
 	tr := httputil.NewTransport(false, "vtselect_backend")
 	tr.TLSHandshakeTimeout = 20 * time.Second
 	tr.DisableCompression = true
@@ -119,6 +127,7 @@ func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *s
 	sn := &storageNode{
 		scheme: scheme,
 		addr:   addr,
+		index:  index,
 		s:      s,
 		c: &http.Client{
 			Transport: ac.NewRoundTripper(tr),
@@ -130,13 +139,35 @@ func newStorageNode(s *Storage, addr string, ac *promauth.Config, isTLS bool) *s
 	return sn
 }
 
-func (sn *storageNode) runQuery(qctx *logstorage.QueryContext, processBlock func(db *logstorage.DataBlock)) error {
-	args := sn.getCommonArgs(QueryProtocolVersion, qctx)
+func (sn *storageNode) runQuery(qctx *logstorage.QueryContext, processBlock func(db *logstorage.DataBlock)) (err error) {
+	profileCollector := qctx.QueryProfileCollector()
+	requestStage, _ := qctx.QueryProfileStage()
+	requestQuery := qctx.Query.String()
+	protocolVersion := QueryProtocolVersion
+	path := "/internal/select/query"
+	if profileCollector != nil {
+		protocolVersion = QueryProfileProtocolVersion
+		path = "/internal/select/query_profile"
+	}
+	args := sn.getCommonArgs(protocolVersion, qctx)
 
 	qsLocal := &logstorage.QueryStats{}
-	defer qctx.QueryStats.UpdateAtomic(qsLocal)
+	if profileCollector != nil {
+		qsLocal.EnableDetailedProfiling()
+	}
+	var queryProfileSnapshot logstorage.QueryProfileSnapshot
+	var gotQueryProfile bool
+	defer func() {
+		qctx.QueryStats.UpdateAtomic(qsLocal)
+		if profileCollector == nil {
+			return
+		}
+		if err != nil && queryProfileSnapshot.Error == "" {
+			queryProfileSnapshot.Error = err.Error()
+		}
+		profileCollector.MergeRemote(queryProfileSnapshot, qsLocal.Snapshot(), sn.addr, sn.index, requestStage, requestQuery)
+	}()
 
-	path := "/internal/select/query"
 	responseBody, reqURL, err := sn.getResponseBodyForPathAndArgs(qctx.Context, path, args)
 	if err != nil {
 		return err
@@ -148,13 +179,26 @@ func (sn *storageNode) runQuery(qctx *logstorage.QueryContext, processBlock func
 	var buf []byte
 	var db logstorage.DataBlock
 	var valuesBuf []string
+	var gotQueryStats bool
+	var queryProfileError string
 	for {
 		if _, err := io.ReadFull(responseBody, dataLenBuf[:]); err != nil {
 			if errors.Is(err, io.EOF) {
-				// The end of response stream
+				// The end of response stream.
+				if profileCollector != nil {
+					if !gotQueryStats {
+						return newUnavailableStorageNodeError("missing terminal query stats block in response from %q", reqURL)
+					}
+					if !gotQueryProfile {
+						return newUnavailableStorageNodeError("missing terminal query profile block in response from %q", reqURL)
+					}
+					if queryProfileError != "" {
+						return fmt.Errorf("remote query at %q failed: %s", reqURL, queryProfileError)
+					}
+				}
 				return nil
 			}
-			return fmt.Errorf("cannot read block size from %q: %w", reqURL, err)
+			return newUnavailableStorageNodeError("cannot read block size from %q: %s", reqURL, err)
 		}
 		blockLen := encoding.UnmarshalUint64(dataLenBuf[:])
 		if blockLen > math.MaxInt {
@@ -163,7 +207,7 @@ func (sn *storageNode) runQuery(qctx *logstorage.QueryContext, processBlock func
 
 		buf = slicesutil.SetLength(buf, int(blockLen))
 		if _, err := io.ReadFull(responseBody, buf); err != nil {
-			return fmt.Errorf("cannot read block with size of %d bytes from %q: %w", blockLen, reqURL, err)
+			return newUnavailableStorageNodeError("cannot read block with size of %d bytes from %q: %s", blockLen, reqURL, err)
 		}
 
 		src := buf
@@ -178,29 +222,59 @@ func (sn *storageNode) runQuery(qctx *logstorage.QueryContext, processBlock func
 		}
 
 		for len(src) > 0 {
-			isQueryStatsBlock := (src[0] == 1)
+			marker := src[0]
 			src = src[1:]
 
-			if isQueryStatsBlock {
+			switch marker {
+			case 0:
+				tail, vb, err := db.UnmarshalInplace(src, valuesBuf[:0])
+				if err != nil {
+					return fmt.Errorf("cannot unmarshal data block received from %q: %w", reqURL, err)
+				}
+				valuesBuf = vb
+				src = tail
+
+				processBlock(&db)
+				clear(valuesBuf)
+			case 1:
 				tail, err := unmarshalQueryStats(qsLocal, src)
 				if err != nil {
 					return fmt.Errorf("cannot unmarshal query stats received from %q: %w", reqURL, err)
 				}
 				src = tail
-				continue
+				gotQueryStats = true
+			case 2:
+				if profileCollector == nil {
+					return fmt.Errorf("unexpected query profile block received from %q", reqURL)
+				}
+				if !gotQueryStats {
+					return fmt.Errorf("query profile block received before terminal query stats block from %q", reqURL)
+				}
+				tail, vb, err := db.UnmarshalInplace(src, valuesBuf[:0])
+				if err != nil {
+					return fmt.Errorf("cannot unmarshal query profile block received from %q: %w", reqURL, err)
+				}
+				valuesBuf = vb
+				src = tail
+				snapshot, err := logstorage.QueryProfileSnapshotFromDataBlock(&db)
+				if err != nil {
+					return fmt.Errorf("cannot decode query profile received from %q: %w", reqURL, err)
+				}
+				queryProfileSnapshot = snapshot
+				gotQueryProfile = true
+				queryProfileError = snapshot.Error
+				clear(valuesBuf)
+			default:
+				return fmt.Errorf("unexpected query response marker %d received from %q", marker, reqURL)
 			}
-
-			tail, vb, err := db.UnmarshalInplace(src, valuesBuf[:0])
-			if err != nil {
-				return fmt.Errorf("cannot unmarshal data block received from %q: %w", reqURL, err)
-			}
-			valuesBuf = vb
-			src = tail
-
-			processBlock(&db)
-
-			clear(valuesBuf)
 		}
+	}
+}
+
+func newUnavailableStorageNodeError(format string, args ...any) error {
+	return &httpserver.ErrorWithStatusCode{
+		Err:        fmt.Errorf(format, args...),
+		StatusCode: http.StatusBadGateway,
 	}
 }
 
@@ -283,6 +357,10 @@ func (sn *storageNode) getCommonArgs(version string, qctx *logstorage.QueryConte
 		logger.Panicf("BUG: cannot marshal HiddenFieldsFilters=%#v: %s", qctx.HiddenFieldsFilters, err)
 	}
 	args.Set("hidden_fields_filters", string(hiddenFieldsFilters))
+	if version == QueryProfileProtocolVersion {
+		stage, _ := qctx.QueryProfileStage()
+		args.Set("profile_stage", stage)
+	}
 
 	return args
 }
@@ -406,7 +484,7 @@ func NewStorage(addrs []string, authCfgs []*promauth.Config, isTLSs []bool, disa
 
 	sns := make([]*storageNode, len(addrs))
 	for i, addr := range addrs {
-		sns[i] = newStorageNode(s, addr, authCfgs[i], isTLSs[i])
+		sns[i] = newStorageNode(s, i, addr, authCfgs[i], isTLSs[i])
 	}
 	s.sns = sns
 
@@ -420,6 +498,10 @@ func (s *Storage) MustStop() {
 
 // RunQuery runs the given qctx and calls writeBlock for the returned data blocks
 func (s *Storage) RunQuery(qctx *logstorage.QueryContext, writeBlock logstorage.WriteDataBlockFunc) error {
+	if qctx.QueryProfileCollector() != nil {
+		stage, _ := qctx.QueryProfileStage()
+		qctx.SetQueryProfileStage(stage, "coordinator")
+	}
 	nqr, err := logstorage.NewNetQueryRunner(qctx, s.RunQuery, writeBlock)
 	if err != nil {
 		return err

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): add an experimental `/select/tempo/api/profile` endpoint for inspecting the query plan and the low-level execution stats of TraceQL search queries. It reports the generated [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/) queries, per-operator row and block flow, the number of the selected and the skipped partitions, parts, index block headers and data blocks, the number of the read bytes, and per-`vtstorage` node stats. See [these docs](https://docs.victoriametrics.com/victoriatraces/querying/#query-profiling).
+
 * BUGFIX: [cluster version](https://docs.victoriametrics.com/victoriatraces/cluster/): evenly spread rerouted data across available `vtstorage` nodes. Previously, healthy nodes adjacent to unavailable nodes in the `-storageNode` list could receive much more data, resulting in uneven resource usage. See [this issue #228](https://github.com/VictoriaMetrics/VictoriaTraces/issues/228).
 
 ## [v0.10.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.10.0)

--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -243,6 +243,7 @@ VictoriaTraces provides the following Tempo HTTP endpoints:
 - `/select/tempo/api/traces/{trace_id}` for fetching a single trace by its ID (v1).
 - `/select/tempo/api/v2/traces/{trace_id}` for fetching a single trace by its ID (v2, similar to v1 but with different data structure).
 - `/select/tempo/api/metrics/query_range` for evaluating a TraceQL metrics query over a time range.
+- `/select/tempo/api/profile` for inspecting the query plan and the execution stats of a TraceQL search query. See [query profiling](#query-profiling).
 
 #### Querying Examples
 
@@ -283,6 +284,55 @@ Here's a response example:
 ```json
 {"series":[{"labels":[{"key":"name","value":{"stringValue":"GET"}}],"samples":[{"timestampMs":"1783567368000","value":346},{"timestampMs":"1783567404000","value":28.166666666666668}],"exemplars":[{"labels":[{"key":"trace:id","value":{"stringValue":"fca92157fc0d84fdaa960f9bc83634f8"}},{"key":"span:id","value":{"stringValue":"38546d070ac097e8"}}],"value":346,"timestampMs":"1783567368000"}]}],"metrics":{"inspectedBytes":"0","inspectedTraces":0,"totalJobs":0,"completedJobs":0},"status":"COMPLETE"}
 ```
+
+#### Query profiling
+
+> Query profiling is **experimental**. The set of the reported fields may change in future releases.
+
+The `/select/tempo/api/profile` endpoint reports how a TraceQL search query at [`/select/tempo/api/search`](#tempo-http-api) is planned and executed.
+It is intended for optimizing both queries and the stored data layout, similar to `EXPLAIN` / `EXPLAIN ANALYZE` in traditional databases.
+
+The endpoint accepts the same `q`, `start`, `end` and `limit` query args as `/select/tempo/api/search`, plus:
+
+- `mode=explain` (default) returns the query plan without reading the stored data.
+- `mode=analyze` executes the query, drops the returned spans and reports the execution stats. It can be also enabled via `analyze=true`.
+
+A TraceQL search request is executed in two stages, which are both reported by this endpoint:
+
+- `trace_id_search` selects `trace_id` values. It starts from the most recent one-minute window and increases the window by 5x
+  until enough traces are found or the requested `start` is reached.
+- `span_fetch` reads all the spans for the selected `trace_id` values. Its time range is extended by `-search.traceMaxDurationWindow`.
+
+Every stage contains the generated [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/) query, together with the queries
+executed at `vtstorage` nodes and the pipes executed at `vtselect` in [cluster version](https://docs.victoriametrics.com/victoriatraces/cluster/).
+
+`mode=analyze` additionally reports for every executed query:
+
+- the number of the processed and the returned rows, blocks and bytes per every pipeline operator;
+- the number of the selected and the skipped partitions, parts, index block headers and data blocks. These stats show how efficiently
+  the query time range and [stream fields](https://docs.victoriametrics.com/victoriatraces/keyconcepts/#stream-fields) prune the stored data;
+- the number of the scheduled, the processed and the canceled data blocks;
+- the number of the read bytes per column headers, bloom filters, values and timestamps;
+- the execution stats per every `vtstorage` node in [cluster version](https://docs.victoriametrics.com/victoriatraces/cluster/).
+
+The reported durations are the summed wall-clock time across all the worker goroutines. They are neither CPU time nor query duration.
+
+For example, the following command returns the query plan without reading the stored data:
+
+```sh
+curl -G http://<victoria-traces>:10428/select/tempo/api/profile \
+  --data-urlencode 'q={ resource.service.name = "frontend" && status = error }'
+```
+
+while the following command also executes the query and returns its execution stats:
+
+```sh
+curl -G http://<victoria-traces>:10428/select/tempo/api/profile \
+  --data-urlencode 'q={ resource.service.name = "frontend" && status = error }' \
+  --data-urlencode 'mode=analyze'
+```
+
+Note that `mode=analyze` reads the stored data in the same way as the regular search query does, so it consumes the same amount of resources.
 
 ## Hidden fields
 

--- a/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/pipe_stream_context.go
+++ b/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/pipe_stream_context.go
@@ -327,7 +327,7 @@ func (pcp *pipeStreamContextProcessor) executeQuery(streamID, qStr string, neede
 	}
 
 	qctxOrig := pcp.pc.qctx
-	qctx := NewQueryContext(ctxWithCancel, qctxOrig.QueryStats, []TenantID{tenantID}, q, qctxOrig.AllowPartialResponse, qctxOrig.HiddenFieldsFilters)
+	qctx := qctxOrig.WithContextAndQuery(ctxWithCancel, q).WithTenantIDs([]TenantID{tenantID})
 	if err := pcp.pc.runQuery(qctx, writeBlock); err != nil {
 		return nil, 0, err
 	}

--- a/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/query_profile.go
+++ b/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/query_profile.go
@@ -1,0 +1,434 @@
+package logstorage
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+)
+
+// QueryProfileSnapshot is a point-in-time, JSON-friendly query profile.
+type QueryProfileSnapshot struct {
+	Queries       []QueryProfileQuery         `json:"queries"`
+	QueryStats    QueryStatsSnapshot          `json:"query_stats"`
+	NodeScanStats []QueryProfileNodeScanStats `json:"node_scan_stats"`
+	Error         string                      `json:"error,omitempty"`
+}
+
+// QueryProfileNodeScanStats contains exact request-level scan stats returned by one storage node.
+type QueryProfileNodeScanStats struct {
+	Node       QueryProfileNode   `json:"node"`
+	Stage      string             `json:"stage,omitempty"`
+	Query      string             `json:"query,omitempty"`
+	QueryStats QueryStatsSnapshot `json:"query_stats"`
+	Error      string             `json:"error,omitempty"`
+}
+
+// QueryProfileQuery describes one physical query execution.
+type QueryProfileQuery struct {
+	ID        string            `json:"id"`
+	Stage     string            `json:"stage,omitempty"`
+	Scope     string            `json:"scope,omitempty"`
+	Query     string            `json:"query"`
+	Node      *QueryProfileNode `json:"node,omitempty"`
+	StartedAt time.Time         `json:"started_at"`
+
+	DurationNsecs int64  `json:"duration_nsecs"`
+	Completed     bool   `json:"completed"`
+	Error         string `json:"error,omitempty"`
+
+	Operators  []QueryProfileOperator `json:"operators"`
+	QueryStats QueryStatsSnapshot     `json:"query_stats"`
+}
+
+// QueryProfileNode identifies a storage node as assigned by the query coordinator.
+type QueryProfileNode struct {
+	Address string `json:"address"`
+	Index   int    `json:"index"`
+}
+
+// QueryProfileOperator describes one operator in physical pipeline order.
+type QueryProfileOperator struct {
+	ID        string `json:"id"`
+	Order     int    `json:"order"`
+	Name      string `json:"name"`
+	Synthetic bool   `json:"synthetic,omitempty"`
+
+	InputBlocks  uint64 `json:"input_blocks"`
+	InputRows    uint64 `json:"input_rows"`
+	OutputBlocks uint64 `json:"output_blocks"`
+	OutputRows   uint64 `json:"output_rows"`
+
+	// InclusiveWriteDurationNsecs includes time spent in downstream operators called by writeBlock.
+	// It is wall-clock duration, not CPU time or self time.
+	InclusiveWriteDurationNsecs int64 `json:"inclusive_write_duration_nsecs"`
+
+	// InclusiveFlushDurationNsecs includes synchronous downstream output generated while flushing.
+	// It is wall-clock duration, not CPU time or self time.
+	InclusiveFlushDurationNsecs int64 `json:"inclusive_flush_duration_nsecs"`
+
+	// DownstreamDurationNsecs is synchronous time spent forwarding output to downstream operators.
+	DownstreamDurationNsecs int64 `json:"downstream_duration_nsecs"`
+
+	// ExclusiveActiveDurationNsecs is inclusive write+flush activity minus synchronous downstream forwarding.
+	// It is summed wall-clock activity across workers, not CPU time.
+	ExclusiveActiveDurationNsecs int64 `json:"exclusive_active_duration_nsecs"`
+
+	Error string `json:"error,omitempty"`
+}
+
+// QueryProfileCollector concurrently collects physical query profiles.
+// A nil collector disables profiling.
+type QueryProfileCollector struct {
+	mu            sync.Mutex
+	nextID        uint64
+	entries       []queryProfileEntry
+	queryStats    *QueryStats
+	nodeScanStats []QueryProfileNodeScanStats
+}
+
+type queryProfileEntry struct {
+	live     *queryProfileQueryLive
+	imported *QueryProfileQuery
+}
+
+// NewQueryProfileCollector returns an empty query profile collector.
+func NewQueryProfileCollector() *QueryProfileCollector {
+	return &QueryProfileCollector{}
+}
+
+func (qpc *QueryProfileCollector) attachQueryStats(qs *QueryStats) {
+	if qpc == nil {
+		return
+	}
+	qpc.mu.Lock()
+	qpc.queryStats = qs
+	qpc.mu.Unlock()
+}
+
+// Snapshot returns a concurrency-safe point-in-time copy of the collected profile,
+// including aggregate QueryStats and exact per-node scan stats when available.
+func (qpc *QueryProfileCollector) Snapshot() QueryProfileSnapshot {
+	if qpc == nil {
+		return QueryProfileSnapshot{
+			Queries:       []QueryProfileQuery{},
+			NodeScanStats: []QueryProfileNodeScanStats{},
+		}
+	}
+
+	qpc.mu.Lock()
+	entries := append([]queryProfileEntry(nil), qpc.entries...)
+	queryStats := qpc.queryStats
+	nodeScanStats := make([]QueryProfileNodeScanStats, len(qpc.nodeScanStats))
+	copy(nodeScanStats, qpc.nodeScanStats)
+	qpc.mu.Unlock()
+
+	queries := make([]QueryProfileQuery, 0, len(entries))
+	for _, entry := range entries {
+		if entry.live != nil {
+			queries = append(queries, entry.live.snapshot())
+			continue
+		}
+		q := cloneQueryProfileQuery(*entry.imported)
+		queries = append(queries, q)
+	}
+	return QueryProfileSnapshot{
+		Queries:       queries,
+		QueryStats:    queryStats.Snapshot(),
+		NodeScanStats: nodeScanStats,
+	}
+}
+
+// MergeRemote merges a remote snapshot and its marker-1 scan stats, then assigns
+// the trusted coordinator-side node identity to both.
+func (qpc *QueryProfileCollector) MergeRemote(snapshot QueryProfileSnapshot, queryStats QueryStatsSnapshot, nodeAddress string, nodeIndex int, requestStage, requestQuery string) {
+	if qpc == nil {
+		return
+	}
+
+	qpc.mu.Lock()
+	defer qpc.mu.Unlock()
+	node := QueryProfileNode{
+		Address: nodeAddress,
+		Index:   nodeIndex,
+	}
+	qpc.nodeScanStats = append(qpc.nodeScanStats, QueryProfileNodeScanStats{
+		Node:       node,
+		Stage:      requestStage,
+		Query:      requestQuery,
+		QueryStats: queryStats,
+		Error:      snapshot.Error,
+	})
+	appendRemote := func(src QueryProfileQuery) {
+		qpc.nextID++
+		q := cloneQueryProfileQuery(src)
+		q.ID = fmt.Sprintf("query-%d", qpc.nextID)
+		q.Node = &QueryProfileNode{
+			Address: node.Address,
+			Index:   node.Index,
+		}
+		for i := range q.Operators {
+			q.Operators[i].ID = fmt.Sprintf("%s-operator-%d", q.ID, i)
+			q.Operators[i].Order = i
+		}
+		qpc.entries = append(qpc.entries, queryProfileEntry{imported: &q})
+	}
+	for _, src := range snapshot.Queries {
+		appendRemote(src)
+	}
+	if snapshot.Error != "" && len(snapshot.Queries) == 0 {
+		appendRemote(QueryProfileQuery{
+			Stage:     requestStage,
+			Scope:     "remote",
+			Query:     requestQuery,
+			StartedAt: time.Now(),
+			Completed: true,
+			Error:     snapshot.Error,
+			Operators: []QueryProfileOperator{},
+		})
+	}
+}
+
+// CreateDataBlock serializes snapshot as JSON in a one-row DataBlock.
+func (qps *QueryProfileSnapshot) CreateDataBlock() (*DataBlock, error) {
+	b, err := json.Marshal(qps)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal query profile: %w", err)
+	}
+	db := &DataBlock{}
+	db.SetColumns([]BlockColumn{{
+		Name:   "QueryProfileJSON",
+		Values: []string{string(b)},
+	}})
+	return db, nil
+}
+
+// QueryProfileSnapshotFromDataBlock decodes a snapshot from a one-row DataBlock.
+func QueryProfileSnapshotFromDataBlock(db *DataBlock) (QueryProfileSnapshot, error) {
+	if db.RowsCount() != 1 {
+		return QueryProfileSnapshot{}, fmt.Errorf("unexpected number of rows in query profile block; got %d; want 1", db.RowsCount())
+	}
+	c := db.GetColumnByName("QueryProfileJSON")
+	if c == nil {
+		return QueryProfileSnapshot{}, fmt.Errorf("missing QueryProfileJSON field in query profile block")
+	}
+	var snapshot QueryProfileSnapshot
+	if err := json.Unmarshal([]byte(c.Values[0]), &snapshot); err != nil {
+		return QueryProfileSnapshot{}, fmt.Errorf("cannot unmarshal query profile JSON: %w", err)
+	}
+	if snapshot.Queries == nil {
+		snapshot.Queries = []QueryProfileQuery{}
+	}
+	if snapshot.NodeScanStats == nil {
+		snapshot.NodeScanStats = []QueryProfileNodeScanStats{}
+	}
+	return snapshot, nil
+}
+
+func cloneQueryProfileQuery(src QueryProfileQuery) QueryProfileQuery {
+	dst := src
+	if src.Node != nil {
+		node := *src.Node
+		dst.Node = &node
+	}
+	dst.Operators = append([]QueryProfileOperator(nil), src.Operators...)
+	return dst
+}
+
+type queryProfileQueryLive struct {
+	id         string
+	stage      string
+	scope      string
+	query      string
+	startedAt  time.Time
+	operators  []*queryProfileOperatorLive
+	queryStats *QueryStats
+	statsStart QueryStatsSnapshot
+
+	durationNsecs atomic.Int64
+	completed     atomic.Bool
+	errMu         sync.Mutex
+	err           string
+}
+
+type queryProfileOperatorLive struct {
+	id        string
+	order     int
+	name      string
+	synthetic bool
+
+	inputBlocks  atomic.Uint64
+	inputRows    atomic.Uint64
+	outputBlocks atomic.Uint64
+	outputRows   atomic.Uint64
+
+	inclusiveWriteDurationNsecs atomic.Int64
+	inclusiveFlushDurationNsecs atomic.Int64
+	downstreamDurationNsecs     atomic.Int64
+	errMu                       sync.Mutex
+	err                         string
+}
+
+func (qpc *QueryProfileCollector) beginQuery(stage, scope, query string, operatorNames []string, synthetic bool, queryStats *QueryStats) *queryProfileQueryLive {
+	qpc.mu.Lock()
+	qpc.nextID++
+	id := fmt.Sprintf("query-%d", qpc.nextID)
+	q := &queryProfileQueryLive{
+		id:         id,
+		stage:      stage,
+		scope:      scope,
+		query:      query,
+		startedAt:  time.Now(),
+		operators:  make([]*queryProfileOperatorLive, len(operatorNames)),
+		queryStats: queryStats,
+		statsStart: queryStats.Snapshot(),
+	}
+	for i, name := range operatorNames {
+		q.operators[i] = &queryProfileOperatorLive{
+			id:        fmt.Sprintf("%s-operator-%d", id, i),
+			order:     i,
+			name:      name,
+			synthetic: synthetic,
+		}
+	}
+	qpc.entries = append(qpc.entries, queryProfileEntry{live: q})
+	qpc.mu.Unlock()
+	return q
+}
+
+func (q *queryProfileQueryLive) finish(err error) {
+	q.durationNsecs.Store(time.Since(q.startedAt).Nanoseconds())
+	if err != nil {
+		q.errMu.Lock()
+		q.err = err.Error()
+		q.errMu.Unlock()
+	}
+	q.completed.Store(true)
+}
+
+func (q *queryProfileQueryLive) snapshot() QueryProfileQuery {
+	operators := make([]QueryProfileOperator, len(q.operators))
+	for i, op := range q.operators {
+		operators[i] = op.snapshot()
+	}
+	q.errMu.Lock()
+	errText := q.err
+	q.errMu.Unlock()
+	durationNsecs := q.durationNsecs.Load()
+	if !q.completed.Load() {
+		durationNsecs = time.Since(q.startedAt).Nanoseconds()
+	}
+	return QueryProfileQuery{
+		ID:            q.id,
+		Stage:         q.stage,
+		Scope:         q.scope,
+		Query:         q.query,
+		StartedAt:     q.startedAt,
+		DurationNsecs: durationNsecs,
+		Completed:     q.completed.Load(),
+		Error:         errText,
+		Operators:     operators,
+		QueryStats:    q.queryStats.Snapshot().Subtract(q.statsStart),
+	}
+}
+
+func (op *queryProfileOperatorLive) snapshot() QueryProfileOperator {
+	op.errMu.Lock()
+	errText := op.err
+	op.errMu.Unlock()
+	writeDuration := op.inclusiveWriteDurationNsecs.Load()
+	flushDuration := op.inclusiveFlushDurationNsecs.Load()
+	downstreamDuration := op.downstreamDurationNsecs.Load()
+	exclusiveDuration := writeDuration + flushDuration - downstreamDuration
+	if exclusiveDuration < 0 {
+		exclusiveDuration = 0
+	}
+	return QueryProfileOperator{
+		ID:                           op.id,
+		Order:                        op.order,
+		Name:                         op.name,
+		Synthetic:                    op.synthetic,
+		InputBlocks:                  op.inputBlocks.Load(),
+		InputRows:                    op.inputRows.Load(),
+		OutputBlocks:                 op.outputBlocks.Load(),
+		OutputRows:                   op.outputRows.Load(),
+		InclusiveWriteDurationNsecs:  writeDuration,
+		InclusiveFlushDurationNsecs:  flushDuration,
+		DownstreamDurationNsecs:      downstreamDuration,
+		ExclusiveActiveDurationNsecs: exclusiveDuration,
+		Error:                        errText,
+	}
+}
+
+func (op *queryProfileOperatorLive) setError(err error) {
+	if err == nil {
+		return
+	}
+	op.errMu.Lock()
+	if op.err == "" {
+		op.err = err.Error()
+	}
+	op.errMu.Unlock()
+}
+
+type queryProfilePipeProcessor struct {
+	op *queryProfileOperatorLive
+	pp pipeProcessor
+}
+
+func (pp *queryProfilePipeProcessor) writeBlock(workerID uint, br *blockResult) {
+	pp.op.inputBlocks.Add(1)
+	pp.op.inputRows.Add(uint64(br.rowsLen))
+	startTime := time.Now()
+	pp.pp.writeBlock(workerID, br)
+	pp.op.inclusiveWriteDurationNsecs.Add(time.Since(startTime).Nanoseconds())
+}
+
+func (pp *queryProfilePipeProcessor) flush() error {
+	startTime := time.Now()
+	err := pp.pp.flush()
+	pp.op.inclusiveFlushDurationNsecs.Add(time.Since(startTime).Nanoseconds())
+	pp.op.setError(err)
+	return err
+}
+
+type queryProfileOutputPipeProcessor struct {
+	op     *queryProfileOperatorLive
+	ppNext pipeProcessor
+}
+
+func (pp *queryProfileOutputPipeProcessor) writeBlock(workerID uint, br *blockResult) {
+	pp.op.outputBlocks.Add(1)
+	pp.op.outputRows.Add(uint64(br.rowsLen))
+	startTime := time.Now()
+	pp.ppNext.writeBlock(workerID, br)
+	pp.op.downstreamDurationNsecs.Add(time.Since(startTime).Nanoseconds())
+}
+
+func (pp *queryProfileOutputPipeProcessor) flush() error {
+	panic("BUG: queryProfileOutputPipeProcessor.flush must not be called")
+}
+
+func getPipeName(p pipe) string {
+	t := reflect.TypeOf(p)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	runes := []rune(strings.TrimPrefix(t.Name(), "pipe"))
+	var b strings.Builder
+	for i, r := range runes {
+		if unicode.IsUpper(r) && i > 0 {
+			prevIsLower := unicode.IsLower(runes[i-1]) || unicode.IsDigit(runes[i-1])
+			nextIsLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if prevIsLower || nextIsLower {
+				b.WriteByte('_')
+			}
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}

--- a/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/query_static_plan.go
+++ b/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/query_static_plan.go
@@ -1,0 +1,58 @@
+package logstorage
+
+// QueryStaticPlan is the execution-independent portion of a query plan.
+type QueryStaticPlan struct {
+	OptimizedQuery       string   `json:"optimized_query"`
+	RemoteQuery          string   `json:"remote_query"`
+	RemotePipeNames      []string `json:"remote_pipe_names"`
+	LocalPipeNames       []string `json:"local_pipe_names"`
+	UnresolvedSubqueries []string `json:"unresolved_subqueries"`
+}
+
+// BuildQueryStaticPlan parses query at timestamp and returns the portions of its optimized
+// distributed plan that can be determined without executing subqueries or accessing storage.
+func BuildQueryStaticPlan(query string, timestamp int64) (QueryStaticPlan, error) {
+	q, err := ParseQueryAtTimestamp(query, timestamp)
+	if err != nil {
+		return QueryStaticPlan{}, err
+	}
+	return GetQueryStaticPlan(q), nil
+}
+
+// GetQueryStaticPlan returns the portions of q's optimized distributed plan that can be
+// determined without executing subqueries or accessing storage.
+func GetQueryStaticPlan(q *Query) QueryStaticPlan {
+	qRemote, pipesLocal := splitQueryToRemoteAndLocal(q)
+	remotePipeNames := make([]string, len(qRemote.pipes))
+	for i, p := range qRemote.pipes {
+		remotePipeNames[i] = getPipeName(p)
+	}
+	localPipeNames := make([]string, len(pipesLocal))
+	for i, p := range pipesLocal {
+		localPipeNames[i] = getPipeName(p)
+	}
+
+	var unresolvedSubqueries []string
+	q.visitSubqueries(func(qSubquery *Query) {
+		if qSubquery != q {
+			unresolvedSubqueries = append(unresolvedSubqueries, qSubquery.String())
+		}
+	})
+	if remotePipeNames == nil {
+		remotePipeNames = []string{}
+	}
+	if localPipeNames == nil {
+		localPipeNames = []string{}
+	}
+	if unresolvedSubqueries == nil {
+		unresolvedSubqueries = []string{}
+	}
+
+	return QueryStaticPlan{
+		OptimizedQuery:       q.String(),
+		RemoteQuery:          qRemote.String(),
+		RemotePipeNames:      remotePipeNames,
+		LocalPipeNames:       localPipeNames,
+		UnresolvedSubqueries: unresolvedSubqueries,
+	}
+}

--- a/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/query_stats.go
+++ b/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/query_stats.go
@@ -44,6 +44,133 @@ type QueryStats struct {
 
 	// BytesProcessedUncompressedValues is the total number of uncompressed values bytes processed during the search.
 	BytesProcessedUncompressedValues uint64
+
+	// PartitionsTotal is the number of partitions present at the time-range selection boundary.
+	PartitionsTotal uint64
+
+	// PartitionsSelected is the number of partitions selected by the query time range.
+	PartitionsSelected uint64
+
+	// PartitionsTimeSkipped is the number of partitions skipped by the query time range.
+	PartitionsTimeSkipped uint64
+
+	// PartsTotal is the number of parts present at the time-range selection boundaries.
+	PartsTotal uint64
+
+	// PartsSelected is the number of parts selected by the query time range.
+	PartsSelected uint64
+
+	// PartsTimeSkipped is the number of parts skipped by the query time range.
+	PartsTimeSkipped uint64
+
+	// IndexBlockHeadersConsidered is the number of index block headers inspected by key traversal.
+	IndexBlockHeadersConsidered uint64
+
+	// IndexBlockHeadersRead is the number of considered index block headers whose block headers were read.
+	IndexBlockHeadersRead uint64
+
+	// IndexBlockHeadersTimeOrKeySkipped is the number of considered index block headers skipped before reading.
+	IndexBlockHeadersTimeOrKeySkipped uint64
+
+	// BlockHeadersDecoded is the number of block headers decoded from index blocks.
+	BlockHeadersDecoded uint64
+
+	// BlockHeadersTimeOrKeySkipped is the number of decoded block headers skipped before scheduling.
+	BlockHeadersTimeOrKeySkipped uint64
+
+	// BlocksScheduled is the number of block searches dispatched to workers.
+	BlocksScheduled uint64
+
+	// BlocksCancelledBeforeProcess is the number of dispatched block searches skipped at the worker cancellation gate.
+	BlocksCancelledBeforeProcess uint64
+
+	// RowsSkippedBeforeScheduling is the number of rows represented by decoded block headers skipped before scheduling.
+	RowsSkippedBeforeScheduling uint64
+
+	detailedProfilingEnabled uint32
+}
+
+// QueryStatsSnapshot is an immutable, JSON-friendly point-in-time copy of QueryStats.
+type QueryStatsSnapshot struct {
+	BytesReadTotal                    uint64 `json:"bytes_read_total"`
+	BytesReadColumnsHeaders           uint64 `json:"bytes_read_columns_headers"`
+	BytesReadColumnsHeaderIndexes     uint64 `json:"bytes_read_columns_header_indexes"`
+	BytesReadBloomFilters             uint64 `json:"bytes_read_bloom_filters"`
+	BytesReadValues                   uint64 `json:"bytes_read_values"`
+	BytesReadTimestamps               uint64 `json:"bytes_read_timestamps"`
+	BytesReadBlockHeaders             uint64 `json:"bytes_read_block_headers"`
+	BlocksProcessed                   uint64 `json:"blocks_processed"`
+	RowsProcessed                     uint64 `json:"rows_processed"`
+	RowsFound                         uint64 `json:"rows_found"`
+	ValuesRead                        uint64 `json:"values_read"`
+	TimestampsRead                    uint64 `json:"timestamps_read"`
+	BytesProcessedUncompressedValues  uint64 `json:"bytes_processed_uncompressed_values"`
+	PartitionsTotal                   uint64 `json:"partitions_total"`
+	PartitionsSelected                uint64 `json:"partitions_selected"`
+	PartitionsTimeSkipped             uint64 `json:"partitions_time_skipped"`
+	PartsTotal                        uint64 `json:"parts_total"`
+	PartsSelected                     uint64 `json:"parts_selected"`
+	PartsTimeSkipped                  uint64 `json:"parts_time_skipped"`
+	IndexBlockHeadersConsidered       uint64 `json:"index_block_headers_considered"`
+	IndexBlockHeadersRead             uint64 `json:"index_block_headers_read"`
+	IndexBlockHeadersTimeOrKeySkipped uint64 `json:"index_block_headers_time_or_key_skipped"`
+	BlockHeadersDecoded               uint64 `json:"block_headers_decoded"`
+	BlockHeadersTimeOrKeySkipped      uint64 `json:"block_headers_time_or_key_skipped"`
+	BlocksScheduled                   uint64 `json:"blocks_scheduled"`
+	BlocksCancelledBeforeProcess      uint64 `json:"blocks_cancelled_before_process"`
+	RowsSkippedBeforeScheduling       uint64 `json:"rows_skipped_before_scheduling"`
+	DetailedProfilingEnabled          bool   `json:"detailed_profiling_enabled"`
+}
+
+// EnableDetailedProfiling enables collection of the opt-in data-layout counters.
+// Once enabled, it remains enabled for the lifetime of qs.
+func (qs *QueryStats) EnableDetailedProfiling() {
+	if qs != nil {
+		atomic.StoreUint32(&qs.detailedProfilingEnabled, 1)
+	}
+}
+
+// DetailedProfilingEnabled reports whether opt-in data-layout counters are enabled.
+func (qs *QueryStats) DetailedProfilingEnabled() bool {
+	return qs != nil && atomic.LoadUint32(&qs.detailedProfilingEnabled) != 0
+}
+
+// Snapshot returns a concurrency-safe point-in-time copy of qs.
+func (qs *QueryStats) Snapshot() QueryStatsSnapshot {
+	if qs == nil {
+		return QueryStatsSnapshot{}
+	}
+	snapshot := QueryStatsSnapshot{
+		BytesReadColumnsHeaders:           atomic.LoadUint64(&qs.BytesReadColumnsHeaders),
+		BytesReadColumnsHeaderIndexes:     atomic.LoadUint64(&qs.BytesReadColumnsHeaderIndexes),
+		BytesReadBloomFilters:             atomic.LoadUint64(&qs.BytesReadBloomFilters),
+		BytesReadValues:                   atomic.LoadUint64(&qs.BytesReadValues),
+		BytesReadTimestamps:               atomic.LoadUint64(&qs.BytesReadTimestamps),
+		BytesReadBlockHeaders:             atomic.LoadUint64(&qs.BytesReadBlockHeaders),
+		BlocksProcessed:                   atomic.LoadUint64(&qs.BlocksProcessed),
+		RowsProcessed:                     atomic.LoadUint64(&qs.RowsProcessed),
+		RowsFound:                         atomic.LoadUint64(&qs.RowsFound),
+		ValuesRead:                        atomic.LoadUint64(&qs.ValuesRead),
+		TimestampsRead:                    atomic.LoadUint64(&qs.TimestampsRead),
+		BytesProcessedUncompressedValues:  atomic.LoadUint64(&qs.BytesProcessedUncompressedValues),
+		PartitionsTotal:                   atomic.LoadUint64(&qs.PartitionsTotal),
+		PartitionsSelected:                atomic.LoadUint64(&qs.PartitionsSelected),
+		PartitionsTimeSkipped:             atomic.LoadUint64(&qs.PartitionsTimeSkipped),
+		PartsTotal:                        atomic.LoadUint64(&qs.PartsTotal),
+		PartsSelected:                     atomic.LoadUint64(&qs.PartsSelected),
+		PartsTimeSkipped:                  atomic.LoadUint64(&qs.PartsTimeSkipped),
+		IndexBlockHeadersConsidered:       atomic.LoadUint64(&qs.IndexBlockHeadersConsidered),
+		IndexBlockHeadersRead:             atomic.LoadUint64(&qs.IndexBlockHeadersRead),
+		IndexBlockHeadersTimeOrKeySkipped: atomic.LoadUint64(&qs.IndexBlockHeadersTimeOrKeySkipped),
+		BlockHeadersDecoded:               atomic.LoadUint64(&qs.BlockHeadersDecoded),
+		BlockHeadersTimeOrKeySkipped:      atomic.LoadUint64(&qs.BlockHeadersTimeOrKeySkipped),
+		BlocksScheduled:                   atomic.LoadUint64(&qs.BlocksScheduled),
+		BlocksCancelledBeforeProcess:      atomic.LoadUint64(&qs.BlocksCancelledBeforeProcess),
+		RowsSkippedBeforeScheduling:       atomic.LoadUint64(&qs.RowsSkippedBeforeScheduling),
+		DetailedProfilingEnabled:          atomic.LoadUint32(&qs.detailedProfilingEnabled) != 0,
+	}
+	snapshot.BytesReadTotal = snapshot.BytesReadColumnsHeaders + snapshot.BytesReadColumnsHeaderIndexes + snapshot.BytesReadBloomFilters + snapshot.BytesReadValues + snapshot.BytesReadTimestamps + snapshot.BytesReadBlockHeaders
+	return snapshot
 }
 
 // GetBytesReadTotal returns the total number of bytes read, which is tracked by qs.
@@ -66,6 +193,24 @@ func (qs *QueryStats) UpdateAtomic(src *QueryStats) {
 	atomic.AddUint64(&qs.ValuesRead, src.ValuesRead)
 	atomic.AddUint64(&qs.TimestampsRead, src.TimestampsRead)
 	atomic.AddUint64(&qs.BytesProcessedUncompressedValues, src.BytesProcessedUncompressedValues)
+
+	if !qs.DetailedProfilingEnabled() {
+		return
+	}
+	atomic.AddUint64(&qs.PartitionsTotal, src.PartitionsTotal)
+	atomic.AddUint64(&qs.PartitionsSelected, src.PartitionsSelected)
+	atomic.AddUint64(&qs.PartitionsTimeSkipped, src.PartitionsTimeSkipped)
+	atomic.AddUint64(&qs.PartsTotal, src.PartsTotal)
+	atomic.AddUint64(&qs.PartsSelected, src.PartsSelected)
+	atomic.AddUint64(&qs.PartsTimeSkipped, src.PartsTimeSkipped)
+	atomic.AddUint64(&qs.IndexBlockHeadersConsidered, src.IndexBlockHeadersConsidered)
+	atomic.AddUint64(&qs.IndexBlockHeadersRead, src.IndexBlockHeadersRead)
+	atomic.AddUint64(&qs.IndexBlockHeadersTimeOrKeySkipped, src.IndexBlockHeadersTimeOrKeySkipped)
+	atomic.AddUint64(&qs.BlockHeadersDecoded, src.BlockHeadersDecoded)
+	atomic.AddUint64(&qs.BlockHeadersTimeOrKeySkipped, src.BlockHeadersTimeOrKeySkipped)
+	atomic.AddUint64(&qs.BlocksScheduled, src.BlocksScheduled)
+	atomic.AddUint64(&qs.BlocksCancelledBeforeProcess, src.BlocksCancelledBeforeProcess)
+	atomic.AddUint64(&qs.RowsSkippedBeforeScheduling, src.RowsSkippedBeforeScheduling)
 }
 
 // UpdateAtomicFromDataBlock adds query stats from db to qs.
@@ -89,6 +234,16 @@ func (qs *QueryStats) UpdateFromDataBlock(db *DataBlock) error {
 		return n
 	}
 
+	getOptionalUint64Entry := func(name string) uint64 {
+		c := db.GetColumnByName(name)
+		if c == nil {
+			return 0
+		}
+		v := c.Values[0]
+		n, _ := tryParseUint64(v)
+		return n
+	}
+
 	qs.BytesReadColumnsHeaders += getUint64Entry("BytesReadColumnsHeaders")
 	qs.BytesReadColumnsHeaderIndexes += getUint64Entry("BytesReadColumnsHeaderIndexes")
 	qs.BytesReadBloomFilters += getUint64Entry("BytesReadBloomFilters")
@@ -103,11 +258,38 @@ func (qs *QueryStats) UpdateFromDataBlock(db *DataBlock) error {
 	qs.TimestampsRead += getUint64Entry("TimestampsRead")
 	qs.BytesProcessedUncompressedValues += getUint64Entry("BytesProcessedUncompressedValues")
 
+	if !qs.DetailedProfilingEnabled() {
+		return errGlobal
+	}
+	qs.PartitionsTotal += getOptionalUint64Entry("PartitionsTotal")
+	qs.PartitionsSelected += getOptionalUint64Entry("PartitionsSelected")
+	qs.PartitionsTimeSkipped += getOptionalUint64Entry("PartitionsTimeSkipped")
+	qs.PartsTotal += getOptionalUint64Entry("PartsTotal")
+	qs.PartsSelected += getOptionalUint64Entry("PartsSelected")
+	qs.PartsTimeSkipped += getOptionalUint64Entry("PartsTimeSkipped")
+	qs.IndexBlockHeadersConsidered += getOptionalUint64Entry("IndexBlockHeadersConsidered")
+	qs.IndexBlockHeadersRead += getOptionalUint64Entry("IndexBlockHeadersRead")
+	qs.IndexBlockHeadersTimeOrKeySkipped += getOptionalUint64Entry("IndexBlockHeadersTimeOrKeySkipped")
+	qs.BlockHeadersDecoded += getOptionalUint64Entry("BlockHeadersDecoded")
+	qs.BlockHeadersTimeOrKeySkipped += getOptionalUint64Entry("BlockHeadersTimeOrKeySkipped")
+	qs.BlocksScheduled += getOptionalUint64Entry("BlocksScheduled")
+	qs.BlocksCancelledBeforeProcess += getOptionalUint64Entry("BlocksCancelledBeforeProcess")
+	qs.RowsSkippedBeforeScheduling += getOptionalUint64Entry("RowsSkippedBeforeScheduling")
+
 	return errGlobal
 }
 
-// CreateDataBlock creates a DataBlock from qs.
+// CreateDataBlock creates a DataBlock from qs, including data-layout selection counters.
 func (qs *QueryStats) CreateDataBlock(queryDurationNsecs int64) *DataBlock {
+	return qs.createDataBlock(queryDurationNsecs, true)
+}
+
+// CreateLegacyDataBlock creates the legacy DataBlock used by v5 cluster protocols.
+func (qs *QueryStats) CreateLegacyDataBlock(queryDurationNsecs int64) *DataBlock {
+	return qs.createDataBlock(queryDurationNsecs, false)
+}
+
+func (qs *QueryStats) createDataBlock(queryDurationNsecs int64, includeSelectionCounters bool) *DataBlock {
 	var cs []BlockColumn
 
 	addUint64Entry := func(name string, value uint64) {
@@ -119,7 +301,11 @@ func (qs *QueryStats) CreateDataBlock(queryDurationNsecs int64) *DataBlock {
 		})
 	}
 
-	qs.addEntries(addUint64Entry, queryDurationNsecs)
+	if includeSelectionCounters {
+		qs.addEntries(addUint64Entry, queryDurationNsecs)
+	} else {
+		qs.addLegacyEntries(addUint64Entry, queryDurationNsecs)
+	}
 
 	return &DataBlock{
 		columns: cs,
@@ -140,7 +326,11 @@ func (qs *QueryStats) writeToPipeProcessor(pp pipeProcessor, queryDurationNsecs 
 		rc.addValue(v)
 	}
 
-	qs.addEntries(addUint64Entry, queryDurationNsecs)
+	if qs.DetailedProfilingEnabled() {
+		qs.addEntries(addUint64Entry, queryDurationNsecs)
+	} else {
+		qs.addLegacyEntries(addUint64Entry, queryDurationNsecs)
+	}
 
 	var br blockResult
 	br.setResultColumns(rcs, 1)
@@ -148,6 +338,32 @@ func (qs *QueryStats) writeToPipeProcessor(pp pipeProcessor, queryDurationNsecs 
 }
 
 func (qs *QueryStats) addEntries(addUint64Entry func(name string, value uint64), queryDurationNsecs int64) {
+	qs.addBaseEntries(addUint64Entry)
+
+	addUint64Entry("PartitionsTotal", qs.PartitionsTotal)
+	addUint64Entry("PartitionsSelected", qs.PartitionsSelected)
+	addUint64Entry("PartitionsTimeSkipped", qs.PartitionsTimeSkipped)
+	addUint64Entry("PartsTotal", qs.PartsTotal)
+	addUint64Entry("PartsSelected", qs.PartsSelected)
+	addUint64Entry("PartsTimeSkipped", qs.PartsTimeSkipped)
+	addUint64Entry("IndexBlockHeadersConsidered", qs.IndexBlockHeadersConsidered)
+	addUint64Entry("IndexBlockHeadersRead", qs.IndexBlockHeadersRead)
+	addUint64Entry("IndexBlockHeadersTimeOrKeySkipped", qs.IndexBlockHeadersTimeOrKeySkipped)
+	addUint64Entry("BlockHeadersDecoded", qs.BlockHeadersDecoded)
+	addUint64Entry("BlockHeadersTimeOrKeySkipped", qs.BlockHeadersTimeOrKeySkipped)
+	addUint64Entry("BlocksScheduled", qs.BlocksScheduled)
+	addUint64Entry("BlocksCancelledBeforeProcess", qs.BlocksCancelledBeforeProcess)
+	addUint64Entry("RowsSkippedBeforeScheduling", qs.RowsSkippedBeforeScheduling)
+
+	addUint64Entry("QueryDurationNsecs", uint64(queryDurationNsecs))
+}
+
+func (qs *QueryStats) addLegacyEntries(addUint64Entry func(name string, value uint64), queryDurationNsecs int64) {
+	qs.addBaseEntries(addUint64Entry)
+	addUint64Entry("QueryDurationNsecs", uint64(queryDurationNsecs))
+}
+
+func (qs *QueryStats) addBaseEntries(addUint64Entry func(name string, value uint64)) {
 	addUint64Entry("BytesReadColumnsHeaders", qs.BytesReadColumnsHeaders)
 	addUint64Entry("BytesReadColumnsHeaderIndexes", qs.BytesReadColumnsHeaderIndexes)
 	addUint64Entry("BytesReadBloomFilters", qs.BytesReadBloomFilters)
@@ -163,6 +379,45 @@ func (qs *QueryStats) addEntries(addUint64Entry func(name string, value uint64),
 	addUint64Entry("ValuesRead", qs.ValuesRead)
 	addUint64Entry("TimestampsRead", qs.TimestampsRead)
 	addUint64Entry("BytesProcessedUncompressedValues", qs.BytesProcessedUncompressedValues)
+}
 
-	addUint64Entry("QueryDurationNsecs", uint64(queryDurationNsecs))
+// Subtract returns the non-negative field-wise difference between qs and before.
+// It is useful for attributing cumulative request stats to a single physical query.
+func (qs QueryStatsSnapshot) Subtract(before QueryStatsSnapshot) QueryStatsSnapshot {
+	sub := func(after, previous uint64) uint64 {
+		if after < previous {
+			return 0
+		}
+		return after - previous
+	}
+	return QueryStatsSnapshot{
+		BytesReadTotal:                    sub(qs.BytesReadTotal, before.BytesReadTotal),
+		BytesReadColumnsHeaders:           sub(qs.BytesReadColumnsHeaders, before.BytesReadColumnsHeaders),
+		BytesReadColumnsHeaderIndexes:     sub(qs.BytesReadColumnsHeaderIndexes, before.BytesReadColumnsHeaderIndexes),
+		BytesReadBloomFilters:             sub(qs.BytesReadBloomFilters, before.BytesReadBloomFilters),
+		BytesReadValues:                   sub(qs.BytesReadValues, before.BytesReadValues),
+		BytesReadTimestamps:               sub(qs.BytesReadTimestamps, before.BytesReadTimestamps),
+		BytesReadBlockHeaders:             sub(qs.BytesReadBlockHeaders, before.BytesReadBlockHeaders),
+		BlocksProcessed:                   sub(qs.BlocksProcessed, before.BlocksProcessed),
+		RowsProcessed:                     sub(qs.RowsProcessed, before.RowsProcessed),
+		RowsFound:                         sub(qs.RowsFound, before.RowsFound),
+		ValuesRead:                        sub(qs.ValuesRead, before.ValuesRead),
+		TimestampsRead:                    sub(qs.TimestampsRead, before.TimestampsRead),
+		BytesProcessedUncompressedValues:  sub(qs.BytesProcessedUncompressedValues, before.BytesProcessedUncompressedValues),
+		PartitionsTotal:                   sub(qs.PartitionsTotal, before.PartitionsTotal),
+		PartitionsSelected:                sub(qs.PartitionsSelected, before.PartitionsSelected),
+		PartitionsTimeSkipped:             sub(qs.PartitionsTimeSkipped, before.PartitionsTimeSkipped),
+		PartsTotal:                        sub(qs.PartsTotal, before.PartsTotal),
+		PartsSelected:                     sub(qs.PartsSelected, before.PartsSelected),
+		PartsTimeSkipped:                  sub(qs.PartsTimeSkipped, before.PartsTimeSkipped),
+		IndexBlockHeadersConsidered:       sub(qs.IndexBlockHeadersConsidered, before.IndexBlockHeadersConsidered),
+		IndexBlockHeadersRead:             sub(qs.IndexBlockHeadersRead, before.IndexBlockHeadersRead),
+		IndexBlockHeadersTimeOrKeySkipped: sub(qs.IndexBlockHeadersTimeOrKeySkipped, before.IndexBlockHeadersTimeOrKeySkipped),
+		BlockHeadersDecoded:               sub(qs.BlockHeadersDecoded, before.BlockHeadersDecoded),
+		BlockHeadersTimeOrKeySkipped:      sub(qs.BlockHeadersTimeOrKeySkipped, before.BlockHeadersTimeOrKeySkipped),
+		BlocksScheduled:                   sub(qs.BlocksScheduled, before.BlocksScheduled),
+		BlocksCancelledBeforeProcess:      sub(qs.BlocksCancelledBeforeProcess, before.BlocksCancelledBeforeProcess),
+		RowsSkippedBeforeScheduling:       sub(qs.RowsSkippedBeforeScheduling, before.RowsSkippedBeforeScheduling),
+		DetailedProfilingEnabled:          qs.DetailedProfilingEnabled,
+	}
 }

--- a/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/storage_search.go
+++ b/vendor/github.com/VictoriaMetrics/VictoriaLogs/lib/logstorage/storage_search.go
@@ -50,27 +50,74 @@ type QueryContext struct {
 	//
 	// It is used for calculating query duration.
 	startTime time.Time
+
+	profileCollector      *QueryProfileCollector
+	profileStage          string
+	profileScope          string
+	profileAggregateStats *QueryStats
 }
 
 // NewQueryContext returns new context for the given query.
 func NewQueryContext(ctx context.Context, qs *QueryStats, tenantIDs []TenantID, q *Query, allowPartialResponse bool, hiddenFieldsFilters []string) *QueryContext {
 	startTime := time.Now()
-	return newQueryContext(ctx, qs, tenantIDs, q, allowPartialResponse, hiddenFieldsFilters, startTime)
+	return newQueryContext(ctx, qs, tenantIDs, q, allowPartialResponse, hiddenFieldsFilters, startTime, nil, "", "", nil)
 }
 
 // WithQuery returns new QueryContext with the given q, while preserving other fields from qctx.
 func (qctx *QueryContext) WithQuery(q *Query) *QueryContext {
-	return newQueryContext(qctx.Context, qctx.QueryStats, qctx.TenantIDs, q, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime)
+	return newQueryContext(qctx.Context, qctx.QueryStats, qctx.TenantIDs, q, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime,
+		qctx.profileCollector, qctx.profileStage, qctx.profileScope, qctx.profileAggregateStats)
 }
 
 // WithContext returns new QueryContext with the given ctx, while preserving other fields from qctx.
 func (qctx *QueryContext) WithContext(ctx context.Context) *QueryContext {
-	return newQueryContext(ctx, qctx.QueryStats, qctx.TenantIDs, qctx.Query, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime)
+	return newQueryContext(ctx, qctx.QueryStats, qctx.TenantIDs, qctx.Query, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime,
+		qctx.profileCollector, qctx.profileStage, qctx.profileScope, qctx.profileAggregateStats)
 }
 
 // WithContextAndQuery returns new QueryContext with the given ctx and q, while preserving other fields from qctx.
 func (qctx *QueryContext) WithContextAndQuery(ctx context.Context, q *Query) *QueryContext {
-	return newQueryContext(ctx, qctx.QueryStats, qctx.TenantIDs, q, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime)
+	return newQueryContext(ctx, qctx.QueryStats, qctx.TenantIDs, q, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime,
+		qctx.profileCollector, qctx.profileStage, qctx.profileScope, qctx.profileAggregateStats)
+}
+
+// WithTenantIDs returns a derived QueryContext for tenantIDs while preserving profiling metadata.
+func (qctx *QueryContext) WithTenantIDs(tenantIDs []TenantID) *QueryContext {
+	return newQueryContext(qctx.Context, qctx.QueryStats, tenantIDs, qctx.Query, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime,
+		qctx.profileCollector, qctx.profileStage, qctx.profileScope, qctx.profileAggregateStats)
+}
+
+func (qctx *QueryContext) withQueryStats(qs *QueryStats) *QueryContext {
+	return newQueryContext(qctx.Context, qs, qctx.TenantIDs, qctx.Query, qctx.AllowPartialResponse, qctx.HiddenFieldsFilters, qctx.startTime,
+		qctx.profileCollector, qctx.profileStage, qctx.profileScope, qctx.profileAggregateStats)
+}
+
+// AttachQueryProfile attaches the optional request-scoped profile collector to qctx.
+// Passing a non-nil collector also enables detailed data-layout accounting in QueryStats.
+// Passing nil detaches the collector; detailed accounting remains enabled once requested.
+func (qctx *QueryContext) AttachQueryProfile(profileCollector *QueryProfileCollector) {
+	qctx.profileCollector = profileCollector
+	if profileCollector != nil {
+		qctx.QueryStats.EnableDetailedProfiling()
+		qctx.profileAggregateStats = qctx.QueryStats
+		profileCollector.attachQueryStats(qctx.QueryStats)
+	}
+}
+
+// SetQueryProfileStage sets the physical execution stage and scope recorded for qctx.
+func (qctx *QueryContext) SetQueryProfileStage(stage, scope string) {
+	qctx.profileStage = stage
+	qctx.profileScope = scope
+}
+
+// QueryProfileStage returns the physical execution stage and scope recorded for qctx.
+func (qctx *QueryContext) QueryProfileStage() (string, string) {
+	return qctx.profileStage, qctx.profileScope
+}
+
+// QueryProfileCollector returns the optional request-scoped profile collector.
+func (qctx *QueryContext) QueryProfileCollector() *QueryProfileCollector {
+	return qctx.profileCollector
 }
 
 // QueryDurationNsecs returns the duration in nanoseconds since the NewQueryContext call.
@@ -78,7 +125,8 @@ func (qctx *QueryContext) QueryDurationNsecs() int64 {
 	return time.Since(qctx.startTime).Nanoseconds()
 }
 
-func newQueryContext(ctx context.Context, qs *QueryStats, tenantIDs []TenantID, q *Query, allowPartialResponse bool, hiddenFieldsFilters []string, startTime time.Time) *QueryContext {
+func newQueryContext(ctx context.Context, qs *QueryStats, tenantIDs []TenantID, q *Query, allowPartialResponse bool, hiddenFieldsFilters []string, startTime time.Time,
+	profileCollector *QueryProfileCollector, profileStage, profileScope string, profileAggregateStats *QueryStats) *QueryContext {
 	if q.opts.allowPartialResponse != nil {
 		// query options override other settings for allowPartialResponse.
 		allowPartialResponse = *q.opts.allowPartialResponse
@@ -93,7 +141,11 @@ func newQueryContext(ctx context.Context, qs *QueryStats, tenantIDs []TenantID, 
 		AllowPartialResponse: allowPartialResponse,
 		HiddenFieldsFilters:  hiddenFieldsFilters,
 
-		startTime: startTime,
+		startTime:             startTime,
+		profileCollector:      profileCollector,
+		profileStage:          profileStage,
+		profileScope:          profileScope,
+		profileAggregateStats: profileAggregateStats,
 	}
 }
 
@@ -217,6 +269,17 @@ func (s *Storage) RunQuery(qctx *QueryContext, writeBlock WriteDataBlockFunc) er
 type runQueryFunc func(qctx *QueryContext, writeBlock writeBlockResultFunc) error
 
 func (s *Storage) runQuery(qctx *QueryContext, writeBlock writeBlockResultFunc) error {
+	if qctx.profileCollector != nil {
+		aggregateStats := qctx.profileAggregateStats
+		if aggregateStats == nil {
+			aggregateStats = qctx.QueryStats
+		}
+		executionStats := &QueryStats{}
+		executionStats.EnableDetailedProfiling()
+		qctx = qctx.withQueryStats(executionStats)
+		defer aggregateStats.UpdateAtomic(executionStats)
+	}
+
 	qNew, err := initSubqueries(qctx, s.runQuery, false)
 	if err != nil {
 		return err
@@ -271,6 +334,13 @@ func (s *Storage) getSearchOptions(tenantIDs []TenantID, q *Query, hiddenFieldsF
 type searchFunc func(stopCh <-chan struct{}, writeBlock writeBlockResultFunc) error
 
 func runPipes(qctx *QueryContext, pipes []pipe, search searchFunc, writeBlock writeBlockResultFunc, concurrency int) error {
+	if qctx.profileCollector == nil {
+		return runPipesUnprofiled(qctx, pipes, search, writeBlock, concurrency)
+	}
+	return runPipesProfiled(qctx, pipes, search, writeBlock, concurrency)
+}
+
+func runPipesUnprofiled(qctx *QueryContext, pipes []pipe, search searchFunc, writeBlock writeBlockResultFunc, concurrency int) error {
 	ctx, topCancel := context.WithCancel(qctx.Context)
 	defer topCancel()
 
@@ -326,6 +396,122 @@ func runPipes(qctx *QueryContext, pipes []pipe, search searchFunc, writeBlock wr
 	}
 
 	return errFlush
+}
+
+func runPipesProfiled(qctx *QueryContext, pipes []pipe, search searchFunc, writeBlock writeBlockResultFunc, concurrency int) (err error) {
+	ctx, topCancel := context.WithCancel(qctx.Context)
+	defer topCancel()
+
+	operatorNames := make([]string, len(pipes)+1)
+	operatorNames[0] = "scan"
+	for i, p := range pipes {
+		operatorNames[i+1] = getPipeName(p)
+	}
+	if len(pipes) == 0 {
+		operatorNames = append(operatorNames, "final_output")
+	}
+	profileStats := qctx.QueryStats
+	if qctx.profileScope == "coordinator" {
+		// Coordinator pipelines consume remote blocks. Their storage stats are reported by each remote node.
+		profileStats = nil
+	}
+	profileQuery := qctx.profileCollector.beginQuery(qctx.profileStage, qctx.profileScope, qctx.Query.String(), operatorNames, false, profileStats)
+	profileQuery.operators[0].synthetic = true
+	if len(pipes) == 0 {
+		profileQuery.operators[1].synthetic = true
+	}
+	defer func() {
+		profileQuery.finish(err)
+	}()
+
+	stopCh := ctx.Done()
+	scanOp := profileQuery.operators[0]
+	if len(pipes) == 0 {
+		outputOp := profileQuery.operators[1]
+		writeProfiled := func(workerID uint, br *blockResult) {
+			rowsCount := uint64(br.rowsLen)
+			scanOp.outputBlocks.Add(1)
+			scanOp.outputRows.Add(rowsCount)
+			outputOp.inputBlocks.Add(1)
+			outputOp.inputRows.Add(rowsCount)
+			startTime := time.Now()
+			writeBlock(workerID, br)
+			duration := time.Since(startTime).Nanoseconds()
+			scanOp.downstreamDurationNsecs.Add(duration)
+			outputOp.inclusiveWriteDurationNsecs.Add(duration)
+			outputOp.outputBlocks.Add(1)
+			outputOp.outputRows.Add(rowsCount)
+		}
+		startTime := time.Now()
+		err = search(stopCh, writeProfiled)
+		scanOp.inclusiveWriteDurationNsecs.Add(time.Since(startTime).Nanoseconds())
+		return err
+	}
+
+	pp := newNoopPipeProcessor(stopCh, writeBlock)
+	cancels := make([]func(), len(pipes))
+	pps := make([]*queryProfilePipeProcessor, len(pipes))
+
+	for i := len(pipes) - 1; i >= 0; i-- {
+		p := pipes[i]
+		op := profileQuery.operators[i+1]
+		ctxChild, cancel := context.WithCancel(ctx)
+		ppOutput := &queryProfileOutputPipeProcessor{
+			op:     op,
+			ppNext: pp,
+		}
+		ppInner := p.newPipeProcessor(concurrency, stopCh, cancel, ppOutput)
+		ppProfiled := &queryProfilePipeProcessor{
+			op: op,
+			pp: ppInner,
+		}
+		pp = ppProfiled
+
+		cancels[i] = cancel
+		pps[i] = ppProfiled
+
+		stopCh = ctxChild.Done()
+		ctx = ctxChild
+	}
+
+	writeScanned := func(workerID uint, br *blockResult) {
+		scanOp.outputBlocks.Add(1)
+		scanOp.outputRows.Add(uint64(br.rowsLen))
+		startTime := time.Now()
+		pp.writeBlock(workerID, br)
+		scanOp.downstreamDurationNsecs.Add(time.Since(startTime).Nanoseconds())
+	}
+	startTime := time.Now()
+	errSearch := search(stopCh, writeScanned)
+	scanOp.inclusiveWriteDurationNsecs.Add(time.Since(startTime).Nanoseconds())
+	if errSearch != nil {
+		topCancel()
+	}
+
+	var errFlush error
+	for i, ppProfiled := range pps {
+		setPipeQueryStats(ppProfiled.pp, qctx.QueryStats, qctx.QueryDurationNsecs())
+
+		if err := ppProfiled.flush(); err != nil && errFlush == nil {
+			topCancel()
+			errFlush = err
+		}
+		cancels[i]()
+	}
+
+	if errSearch != nil {
+		return errSearch
+	}
+	return errFlush
+}
+
+func setPipeQueryStats(pp pipeProcessor, qs *QueryStats, queryDurationNsecs int64) {
+	switch t := pp.(type) {
+	case *pipeQueryStatsProcessor:
+		t.setQueryStats(qs, queryDurationNsecs)
+	case *pipeQueryStatsLocalProcessor:
+		t.setQueryStats(qs, queryDurationNsecs)
+	}
 }
 
 // GetFieldNames returns field names for the given qctx.
@@ -1306,6 +1492,8 @@ func (db *DataBlock) mustInitFromBlockResult(br *blockResult) {
 //
 // It uses workersCount parallel workers for the search and calls writeBlock for each matching block.
 func (s *Storage) searchParallel(workersCount int, sso *storageSearchOptions, qs *QueryStats, stopCh <-chan struct{}, writeBlock writeBlockResultFunc) {
+	collectDetailedStats := qs.DetailedProfilingEnabled()
+
 	// spin up workers
 	var wg sync.WaitGroup
 	workCh := make(chan *blockSearchWorkBatch, workersCount)
@@ -1321,6 +1509,9 @@ func (s *Storage) searchParallel(workersCount int, sso *storageSearchOptions, qs
 					bsw := &bsws[i]
 					if needStop(stopCh) {
 						// The search has been canceled. Just skip all the scheduled work in order to save CPU time.
+						if collectDetailedStats {
+							qsLocal.BlocksCancelledBeforeProcess++
+						}
 						bsw.reset()
 						continue
 					}
@@ -1351,8 +1542,16 @@ func (s *Storage) searchParallel(workersCount int, sso *storageSearchOptions, qs
 		})
 	}
 
-	// Select partitions according to the selected time range
-	ptws, ptwsDecRef := s.getPartitionsForTimeRange(sso.minTimestamp, sso.maxTimestamp)
+	// Select partitions according to the selected time range.
+	var ptws []*partitionWrapper
+	var ptwsDecRef func()
+	if collectDetailedStats {
+		var qsSelection QueryStats
+		ptws, ptwsDecRef = s.getPartitionsForTimeRangeWithStats(sso.minTimestamp, sso.maxTimestamp, &qsSelection)
+		qs.UpdateAtomic(&qsSelection)
+	} else {
+		ptws, ptwsDecRef = s.getPartitionsForTimeRange(sso.minTimestamp, sso.maxTimestamp)
+	}
 	defer ptwsDecRef()
 
 	// Schedule concurrent search across matching partitions.
@@ -1363,7 +1562,7 @@ func (s *Storage) searchParallel(workersCount int, sso *storageSearchOptions, qs
 		wgSearchers.Go(func() {
 			qsLocal := &QueryStats{}
 
-			psfs[idx] = ptw.pt.search(sso, qsLocal, workCh, stopCh)
+			psfs[idx] = ptw.pt.search(sso, qsLocal, workCh, stopCh, collectDetailedStats)
 
 			qs.UpdateAtomic(qsLocal)
 
@@ -1386,7 +1585,15 @@ func (s *Storage) searchParallel(workersCount int, sso *storageSearchOptions, qs
 //
 // The caller must call ptwsDecRef when the returned partitions are no longer needed.
 func (s *Storage) getPartitionsForTimeRange(minTimestamp, maxTimestamp int64) (ptws []*partitionWrapper, ptwsDecRef func()) {
+	return s.getPartitionsForTimeRangeWithStats(minTimestamp, maxTimestamp, nil)
+}
+
+func (s *Storage) getPartitionsForTimeRangeWithStats(minTimestamp, maxTimestamp int64, qs *QueryStats) (ptws []*partitionWrapper, ptwsDecRef func()) {
 	s.partitionsLock.Lock()
+
+	if qs != nil {
+		qs.PartitionsTotal += uint64(len(s.partitions))
+	}
 
 	// s.partitions are sorted by s.day. Use binary search for finding partitions for the given [minTimestamp, maxTimestamp] time range.
 	ptwsTmp := s.partitions
@@ -1403,6 +1610,11 @@ func (s *Storage) getPartitionsForTimeRange(minTimestamp, maxTimestamp int64) (p
 
 	// Copy the selected partitions, so they don't interfere with s.partitions.
 	ptws = append([]*partitionWrapper{}, ptwsTmp...)
+	if qs != nil {
+		selected := uint64(len(ptws))
+		qs.PartitionsSelected += selected
+		qs.PartitionsTimeSkipped += uint64(len(s.partitions)) - selected
+	}
 
 	for _, ptw := range ptws {
 		ptw.incRef()
@@ -1426,14 +1638,14 @@ var partitionSearchConcurrencyLimitCh = make(chan struct{}, cgroup.AvailableCPUs
 
 type partitionSearchFinalizer func()
 
-func (pt *partition) search(sso *storageSearchOptions, qs *QueryStats, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}) partitionSearchFinalizer {
+func (pt *partition) search(sso *storageSearchOptions, qs *QueryStats, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}, collectDetailedStats bool) partitionSearchFinalizer {
 	if needStop(stopCh) {
 		// Do not spend CPU time on search, since it is already stopped.
 		return func() {}
 	}
 
 	pso := pt.getSearchOptions(sso)
-	return pt.ddb.search(pso, qs, workCh, stopCh)
+	return pt.ddb.search(pso, qs, workCh, stopCh, collectDetailedStats)
 }
 
 func (pt *partition) getSearchOptions(sso *storageSearchOptions) *partitionSearchOptions {
@@ -1523,13 +1735,19 @@ func initStreamFilters(tenantIDs []TenantID, idb *indexdb, f filter) filter {
 	return f
 }
 
-func (ddb *datadb) search(pso *partitionSearchOptions, qs *QueryStats, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}) partitionSearchFinalizer {
-	// Select parts with data for the given time range
-	pws, pwsDecRef := ddb.getPartsForTimeRange(pso.minTimestamp, pso.maxTimestamp)
+func (ddb *datadb) search(pso *partitionSearchOptions, qs *QueryStats, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}, collectDetailedStats bool) partitionSearchFinalizer {
+	// Select parts with data for the given time range.
+	var pws []*partWrapper
+	var pwsDecRef func()
+	if collectDetailedStats {
+		pws, pwsDecRef = ddb.getPartsForTimeRangeWithStats(pso.minTimestamp, pso.maxTimestamp, qs)
+	} else {
+		pws, pwsDecRef = ddb.getPartsForTimeRange(pso.minTimestamp, pso.maxTimestamp)
+	}
 
 	// Apply search to matching parts
 	for _, pw := range pws {
-		pw.p.search(pso, qs, workCh, stopCh)
+		pw.p.search(pso, qs, workCh, stopCh, collectDetailedStats)
 	}
 
 	return pwsDecRef
@@ -1539,10 +1757,23 @@ func (ddb *datadb) search(pso *partitionSearchOptions, qs *QueryStats, workCh ch
 //
 // The caller must call pwsDecRef on the returned parts when they are no longer needed.
 func (ddb *datadb) getPartsForTimeRange(minTimestamp, maxTimestamp int64) (pws []*partWrapper, pwsDecRef func()) {
+	return ddb.getPartsForTimeRangeWithStats(minTimestamp, maxTimestamp, nil)
+}
+
+func (ddb *datadb) getPartsForTimeRangeWithStats(minTimestamp, maxTimestamp int64, qs *QueryStats) (pws []*partWrapper, pwsDecRef func()) {
 	ddb.partsLock.Lock()
+	partsTotal := len(ddb.bigParts) + len(ddb.smallParts) + len(ddb.inmemoryParts)
+	if qs != nil {
+		qs.PartsTotal += uint64(partsTotal)
+	}
 	pws = appendPartsInTimeRange(nil, ddb.bigParts, minTimestamp, maxTimestamp)
 	pws = appendPartsInTimeRange(pws, ddb.smallParts, minTimestamp, maxTimestamp)
 	pws = appendPartsInTimeRange(pws, ddb.inmemoryParts, minTimestamp, maxTimestamp)
+	if qs != nil {
+		selected := uint64(len(pws))
+		qs.PartsSelected += selected
+		qs.PartsTimeSkipped += uint64(partsTotal) - selected
+	}
 
 	for _, pw := range pws {
 		pw.incRef()
@@ -1558,12 +1789,12 @@ func (ddb *datadb) getPartsForTimeRange(minTimestamp, maxTimestamp int64) (pws [
 	return pws, pwsDecRef
 }
 
-func (p *part) search(pso *partitionSearchOptions, qs *QueryStats, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}) {
+func (p *part) search(pso *partitionSearchOptions, qs *QueryStats, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}, collectDetailedStats bool) {
 	bhss := getBlockHeaders()
 	if len(pso.tenantIDs) > 0 {
-		p.searchByTenantIDs(pso, qs, bhss, workCh, stopCh)
+		p.searchByTenantIDs(pso, qs, bhss, workCh, stopCh, collectDetailedStats)
 	} else {
-		p.searchByStreamIDs(pso, qs, bhss, workCh, stopCh)
+		p.searchByStreamIDs(pso, qs, bhss, workCh, stopCh, collectDetailedStats)
 	}
 	putBlockHeaders(bhss)
 }
@@ -1607,7 +1838,7 @@ func (p *part) hasMatchingRows(pso *partitionSearchOptions, stopCh <-chan struct
 
 	// execute the search
 	var qs QueryStats
-	p.search(pso, &qs, workCh, stopCh)
+	p.search(pso, &qs, workCh, stopCh, false)
 
 	// Wait until workers finish their work
 	close(workCh)
@@ -1643,7 +1874,30 @@ func (bhss *blockHeaders) reset() {
 	bhss.bhs = bhs[:0]
 }
 
-func (p *part) searchByTenantIDs(pso *partitionSearchOptions, qs *QueryStats, bhss *blockHeaders, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}) {
+func accountDecodedBlockHeaders(qs *QueryStats, bhs []blockHeader) {
+	qs.BlockHeadersDecoded += uint64(len(bhs))
+	qs.BlockHeadersTimeOrKeySkipped += uint64(len(bhs))
+	for i := range bhs {
+		qs.RowsSkippedBeforeScheduling += bhs[i].rowsCount
+	}
+}
+
+func getBlockSearchWorkBatchStats(bswb *blockSearchWorkBatch) (uint64, uint64) {
+	bsws := bswb.bsws
+	var rowsCount uint64
+	for i := range bsws {
+		rowsCount += bsws[i].bh.rowsCount
+	}
+	return uint64(len(bsws)), rowsCount
+}
+
+func accountDispatchedBlockSearchBatch(qs *QueryStats, blocksCount, rowsCount uint64) {
+	qs.BlocksScheduled += blocksCount
+	qs.BlockHeadersTimeOrKeySkipped -= blocksCount
+	qs.RowsSkippedBeforeScheduling -= rowsCount
+}
+
+func (p *part) searchByTenantIDs(pso *partitionSearchOptions, qs *QueryStats, bhss *blockHeaders, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}, collectDetailedStats bool) {
 	// it is assumed that tenantIDs are sorted
 	tenantIDs := pso.tenantIDs
 
@@ -1652,10 +1906,17 @@ func (p *part) searchByTenantIDs(pso *partitionSearchOptions, qs *QueryStats, bh
 		if bswb.appendBlockSearchWork(p, pso, bh) {
 			return true
 		}
+		var blocksCount, rowsCount uint64
+		if collectDetailedStats {
+			blocksCount, rowsCount = getBlockSearchWorkBatchStats(bswb)
+		}
 		select {
 		case <-stopCh:
 			return false
 		case workCh <- bswb:
+			if collectDetailedStats {
+				accountDispatchedBlockSearchBatch(qs, blocksCount, rowsCount)
+			}
 			bswb = getBlockSearchWorkBatch()
 			return true
 		}
@@ -1694,13 +1955,25 @@ func (p *part) searchByTenantIDs(pso *partitionSearchOptions, qs *QueryStats, bh
 		}
 		ibh := &ibhs[n]
 		ibhs = ibhs[n+1:]
+		if collectDetailedStats {
+			considered := uint64(n + 1)
+			qs.IndexBlockHeadersConsidered += considered
+			qs.IndexBlockHeadersTimeOrKeySkipped += considered
+		}
 
 		if pso.minTimestamp > ibh.maxTimestamp || pso.maxTimestamp < ibh.minTimestamp {
 			// Skip the ibh, since it doesn't contain entries on the requested time range
 			continue
 		}
 
+		if collectDetailedStats {
+			qs.IndexBlockHeadersRead++
+			qs.IndexBlockHeadersTimeOrKeySkipped--
+		}
 		bhss.bhs = ibh.mustReadBlockHeaders(bhss.bhs[:0], p, qs)
+		if collectDetailedStats {
+			accountDecodedBlockHeaders(qs, bhss.bhs)
+		}
 
 		bhs := bhss.bhs
 		for len(bhs) > 0 {
@@ -1738,14 +2011,21 @@ func (p *part) searchByTenantIDs(pso *partitionSearchOptions, qs *QueryStats, bh
 		}
 	}
 
-	// Flush the remaining work
+	// Flush the remaining work.
+	var blocksCount, rowsCount uint64
+	if collectDetailedStats {
+		blocksCount, rowsCount = getBlockSearchWorkBatchStats(bswb)
+	}
 	select {
 	case <-stopCh:
 	case workCh <- bswb:
+		if collectDetailedStats {
+			accountDispatchedBlockSearchBatch(qs, blocksCount, rowsCount)
+		}
 	}
 }
 
-func (p *part) searchByStreamIDs(pso *partitionSearchOptions, qs *QueryStats, bhss *blockHeaders, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}) {
+func (p *part) searchByStreamIDs(pso *partitionSearchOptions, qs *QueryStats, bhss *blockHeaders, workCh chan<- *blockSearchWorkBatch, stopCh <-chan struct{}, collectDetailedStats bool) {
 	// it is assumed that streamIDs are sorted
 	streamIDs := pso.streamIDs
 
@@ -1754,10 +2034,17 @@ func (p *part) searchByStreamIDs(pso *partitionSearchOptions, qs *QueryStats, bh
 		if bswb.appendBlockSearchWork(p, pso, bh) {
 			return true
 		}
+		var blocksCount, rowsCount uint64
+		if collectDetailedStats {
+			blocksCount, rowsCount = getBlockSearchWorkBatchStats(bswb)
+		}
 		select {
 		case <-stopCh:
 			return false
 		case workCh <- bswb:
+			if collectDetailedStats {
+				accountDispatchedBlockSearchBatch(qs, blocksCount, rowsCount)
+			}
 			bswb = getBlockSearchWorkBatch()
 			return true
 		}
@@ -1797,13 +2084,25 @@ func (p *part) searchByStreamIDs(pso *partitionSearchOptions, qs *QueryStats, bh
 		}
 		ibh := &ibhs[n]
 		ibhs = ibhs[n+1:]
+		if collectDetailedStats {
+			considered := uint64(n + 1)
+			qs.IndexBlockHeadersConsidered += considered
+			qs.IndexBlockHeadersTimeOrKeySkipped += considered
+		}
 
 		if pso.minTimestamp > ibh.maxTimestamp || pso.maxTimestamp < ibh.minTimestamp {
 			// Skip the ibh, since it doesn't contain entries on the requested time range
 			continue
 		}
 
+		if collectDetailedStats {
+			qs.IndexBlockHeadersRead++
+			qs.IndexBlockHeadersTimeOrKeySkipped--
+		}
 		bhss.bhs = ibh.mustReadBlockHeaders(bhss.bhs[:0], p, qs)
+		if collectDetailedStats {
+			accountDecodedBlockHeaders(qs, bhss.bhs)
+		}
 
 		bhs := bhss.bhs
 		for len(bhs) > 0 {
@@ -1841,10 +2140,17 @@ func (p *part) searchByStreamIDs(pso *partitionSearchOptions, qs *QueryStats, bh
 		}
 	}
 
-	// Flush the remaining work
+	// Flush the remaining work.
+	var blocksCount, rowsCount uint64
+	if collectDetailedStats {
+		blocksCount, rowsCount = getBlockSearchWorkBatchStats(bswb)
+	}
 	select {
 	case <-stopCh:
 	case workCh <- bswb:
+		if collectDetailedStats {
+			accountDispatchedBlockSearchBatch(qs, blocksCount, rowsCount)
+		}
 	}
 }
 


### PR DESCRIPTION
Add an experimental `/select/tempo/api/profile` endpoint, which reports how a TraceQL search query is planned and executed, similar to EXPLAIN / EXPLAIN ANALYZE in traditional databases.

`mode=explain` (default) returns the static plan without reading the stored data: the two generated LogsQL stages (`trace_id_search` and `span_fetch`), the query executed at vtstorage nodes, the pipes executed at vtselect and the unresolved subqueries.

`mode=analyze` executes the query, drops the returned spans and reports:
- per-operator input/output rows and blocks plus scan, inclusive, downstream and exclusive-active durations;
- the number of the selected and the skipped partitions, parts, index block headers and data blocks, which shows how efficiently the query time range and the stream fields prune the stored data;
- the number of the scheduled, the processed and the canceled data blocks;
- the number of the read bytes per column headers, bloom filters, values and timestamps;
- stats per physical query, per vtstorage node and for the whole request.

Profiling is opt-in per query context, so ordinary queries keep the original execution path. In cluster mode the profiles are transferred via the dedicated `/internal/select/query_profile` endpoint, so the `/internal/select/query` protocol and its stats block stay unchanged.

CPU time, peak memory usage, bloom filter row selectivity and stream index bytes are intentionally not reported, since they cannot be measured exactly at the moment.

### Describe Your Changes

Please provide a brief description of the changes you made. Be as specific as possible to help others understand the purpose and impact of your modifications.

### Checklist

The following checks are **mandatory**:

- [ ] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [ ] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
