### PR TITLE
Docs: Add SEO meta descriptions to all pages

### DIFF
--- a/docs/victoriatraces/_index.md
+++ b/docs/victoriatraces/_index.md
@@ -1,5 +1,6 @@
 ---
 title: VictoriaTraces
+description: "Documentation for VictoriaTraces, a database for storing and querying distributed traces."
 weight: 0
 menu:
   docs:

--- a/docs/victoriatraces/changelog/CHANGELOG_2025.md
+++ b/docs/victoriatraces/changelog/CHANGELOG_2025.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Year 2025
+description: "VictoriaTraces release history and changes for 2025."
 search:
   weight: 0.1
 menu:

--- a/docs/victoriatraces/changelog/_index.md
+++ b/docs/victoriatraces/changelog/_index.md
@@ -1,6 +1,7 @@
 ---
 weight: 100
 title: CHANGELOG
+description: "Release history for VictoriaTraces"
 menu:
   docs:
     identifier: vt-changelog

--- a/docs/victoriatraces/cluster.md
+++ b/docs/victoriatraces/cluster.md
@@ -1,6 +1,7 @@
 ---
 weight: 3
 title: VictoriaTraces cluster
+description: "Deploy VictoriaTraces cluster with vtinsert, vtselect, and vtstorage."
 menu:
   docs:
     parent: victoriatraces

--- a/docs/victoriatraces/data-ingestion/_index.md
+++ b/docs/victoriatraces/data-ingestion/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Data ingestion
+description: "Accept trace spans via OpenTelemetry Protocol (OTLP) into VictoriaTraces."
 weight: 4
 menu:
   docs:

--- a/docs/victoriatraces/data-ingestion/opentelemetry.md
+++ b/docs/victoriatraces/data-ingestion/opentelemetry.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: OpenTelemetry setup
+description: "Configure the OTel SDK or Collector to send traces to VictoriaTraces."
 disableToc: true
 menu:
   docs:

--- a/docs/victoriatraces/keyConcepts.md
+++ b/docs/victoriatraces/keyConcepts.md
@@ -1,6 +1,7 @@
 ---
 weight: 2
 title: Key concepts
+description: "VictoriaTraces tracing data model, spans, resources, service discovery, and LogsQL-based querying."
 menu:
   docs:
     identifier: vt-key-concepts

--- a/docs/victoriatraces/querying/_index.md
+++ b/docs/victoriatraces/querying/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Querying
+description: "Query VictoriaTraces traces via LogsQL, Web UI, and HTTP API."
 weight: 5
 menu:
   docs:

--- a/docs/victoriatraces/querying/grafana.md
+++ b/docs/victoriatraces/querying/grafana.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: Visualization in Grafana
+description: "Visualize VictoriaTraces traces in Grafana using the Jaeger datasource."
 disableToc: true
 menu:
   docs:

--- a/docs/victoriatraces/querying/grafana.md
+++ b/docs/victoriatraces/querying/grafana.md
@@ -1,7 +1,7 @@
 ---
 weight: 4
 title: Visualization in Grafana
-description: "Visualize VictoriaTraces traces in Grafana using the Jaeger datasource."
+description: "Visualize VictoriaTraces traces in Grafana using the Jaeger and the Tempo datasource."
 disableToc: true
 menu:
   docs:

--- a/docs/victoriatraces/querying/jaeger-frontend.md
+++ b/docs/victoriatraces/querying/jaeger-frontend.md
@@ -1,6 +1,7 @@
 ---
 weight: 4
 title: Visualization in Jaeger UI
+description: "Visualize VictoriaTraces traces using the Jaeger Query Service UI."
 disableToc: true
 menu:
   docs:

--- a/docs/victoriatraces/quick-start.md
+++ b/docs/victoriatraces/quick-start.md
@@ -1,6 +1,7 @@
 ---
 weight: 1
 title: Quick start
+description: "Get started with VictoriaTraces. Single-node and cluster deployment."
 menu:
   docs:
     identifier: vt-quick-start

--- a/docs/victoriatraces/roadmap.md
+++ b/docs/victoriatraces/roadmap.md
@@ -1,6 +1,7 @@
 ---
 weight: 30
 title: Roadmap
+description: "Upcoming features toward GA release of VictoriaTraces."
 menu:
   docs:
     identifier: vt-roadmap

--- a/docs/victoriatraces/troubleshooting.md
+++ b/docs/victoriatraces/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 weight: 20
 title: Troubleshooting
+description: "Common issues and solutions for VictoriaTraces"
 menu:
   docs:
     identifier: vt-troubleshooting

--- a/docs/victoriatraces/vmalert.md
+++ b/docs/victoriatraces/vmalert.md
@@ -1,7 +1,7 @@
 ---
 weight: 6
 title: Alerting with traces
-description: "Configure vmalert on VictoriaTraces trace stats queries."
+description: "Configure vmalert to query VictoriaTraces trace statistics."
 menu:
   docs:
     parent: "victoriatraces"

--- a/docs/victoriatraces/vmalert.md
+++ b/docs/victoriatraces/vmalert.md
@@ -1,6 +1,7 @@
 ---
 weight: 6
 title: Alerting with traces
+description: "Configure vmalert on VictoriaTraces trace stats queries."
 menu:
   docs:
     parent: "victoriatraces"


### PR DESCRIPTION
### Describe Your Changes

This PR add meta descriptions to every page in the docs in this repository. Right now, we have one general meta description for every page. This PR adds page-specific descriptions.

Meta descriptions are not likely to improve rankings on search engines but can improve CTRs. They can also be used to keep LLMs.txt updated as new pages are added (by adding an automation later).

The descriptions were taken from LLMs.txt, so they were already reviewed in https://github.com/VictoriaMetrics/vmdocs/pull/251
I only tweaked those that needed trimming to fit into the 160 SEO character limit. We also revised them with our SEO specialist (Jonathan). So I think it's a good staring point.

I'm going to open a PR for every repository that contributes to the docs and add descriptions so eventually every page in the docs has a dedicated meta descriptions.

### Checklist

The following checks are **mandatory**:

- [X] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [X] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
