### PR TITLE
vtselect: match span events and links in the Tempo search API

### DIFF
--- a/app/vtselect/traces/tempo/metrics_query.go
+++ b/app/vtselect/traces/tempo/metrics_query.go
@@ -129,7 +129,8 @@ func buildStatsQuery(filterStr string, vtByFields []string, statsExpr string) st
 // quantile and a map of alias→quantile-value so the executor can attach a `p`
 // label that distinguishes the resulting series.
 func metricsToLogsQLStats(funcName, fieldName string, quantiles []string) (statsExpr string, valueColumnLabels map[string]string, err error) {
-	vtField := quoteLogsQLField(traceql.TraceQLFieldToVTField(fieldName))
+	vtFieldName := traceql.TraceQLFieldToVTField(fieldName)
+	vtField := quoteLogsQLField(vtFieldName)
 	switch funcName {
 	case "rate":
 		return "rate() as value", nil, nil
@@ -144,6 +145,12 @@ func metricsToLogsQLStats(funcName, fieldName string, quantiles []string) (stats
 	case "sum_over_time":
 		return "sum(" + vtField + ") as value", nil, nil
 	case "histogram_over_time":
+		// histogram() reads a single named field, so it rejects the ":*" wildcard which
+		// event and link fields carry. Fail here with the offending field rather than
+		// let LogsQL fail to parse the generated query.
+		if strings.HasSuffix(vtFieldName, ":*") {
+			return "", nil, fmt.Errorf("histogram_over_time does not support the event and link scopes; got %q", fieldName)
+		}
 		return "histogram(" + vtField + ") as value", nil, nil
 	case "quantile_over_time":
 		if len(quantiles) == 0 {

--- a/app/vtselect/traces/tempo/metrics_query_test.go
+++ b/app/vtselect/traces/tempo/metrics_query_test.go
@@ -270,6 +270,37 @@ func TestTranslateMetricsQueryErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid query")
 	}
+
+	// histogram() reads a single named field, so it rejects the ":*" wildcard which the
+	// event and link scopes carry. Reject it up front rather than emit LogsQL which
+	// fails to parse and shows the user an internal field name.
+	for _, q := range []string{
+		`{} | histogram_over_time(event.foo)`,
+		`{} | histogram_over_time(link.foo)`,
+		`{} | histogram_over_time(event:name)`,
+	} {
+		if _, err = translateMetricsQuery(q, ts); err == nil {
+			t.Fatalf("expected error for %s", q)
+		}
+	}
+
+	// The other aggregations do accept the wildcard. Parse what they generate, so that a
+	// query which reaches the storage layer is proven to be valid rather than assumed.
+	for _, q := range []string{
+		`{} | min_over_time(event.foo)`,
+		`{} | max_over_time(link.foo)`,
+		`{} | avg_over_time(event.foo)`,
+		`{} | sum_over_time(event.foo)`,
+		`{} | quantile_over_time(event.foo, 0.9)`,
+	} {
+		tr, err := translateMetricsQuery(q, ts)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %s", q, err)
+		}
+		if _, err = logstorage.ParseQueryAtTimestamp(tr.baseQuery, ts); err != nil {
+			t.Fatalf("%s generated LogsQL which does not parse [%s]: %s", q, tr.baseQuery, err)
+		}
+	}
 }
 
 // TestTranslateMetricsQueryQuantileLabels verifies that quantile_over_time

--- a/app/vtselect/traces/tempo/tempo.go
+++ b/app/vtselect/traces/tempo/tempo.go
@@ -162,6 +162,10 @@ func processSearchTagValuesRequest(ctx context.Context, w http.ResponseWriter, r
 		} else if strings.HasPrefix(tagName, "span.") {
 			mappedTagName = otelpb.SpanAttrPrefixField + tagName[len("span."):]
 		} else if strings.HasPrefix(tagName, "event.") {
+			// Unlike traceql.TraceQLFieldToVTField, this must not append the ":*" event
+			// index wildcard. searchTagValues below feeds the name to the field_values
+			// pipe, which reads a single named field. Neither form works today: listing
+			// event attribute values needs LogsQL to collect values across fields first.
 			mappedTagName = otelpb.EventPrefix + otelpb.EventAttrPrefix + tagName[len("event."):]
 		} else {
 			mappedTagName = tagName

--- a/apptest/model.go
+++ b/apptest/model.go
@@ -324,6 +324,38 @@ type DependenciesResponseData struct {
 	CallCount int    `json:"callCount"`
 }
 
+// TempoAPISearchResponse is an in-memory representation of the
+// /select/tempo/api/search response.
+type TempoAPISearchResponse struct {
+	Traces []TempoAPISearchTrace `json:"traces"`
+}
+
+// TempoAPISearchTrace is a single trace of a TempoAPISearchResponse.
+type TempoAPISearchTrace struct {
+	TraceID string `json:"traceID"`
+}
+
+// TraceIDs returns the trace IDs of the response in the order they were returned.
+func (r *TempoAPISearchResponse) TraceIDs() []string {
+	traceIDs := make([]string, len(r.Traces))
+	for i, trace := range r.Traces {
+		traceIDs[i] = trace.TraceID
+	}
+	return traceIDs
+}
+
+// NewTempoAPISearchResponse is a test helper function that creates a new
+// instance of TempoAPISearchResponse by unmarshalling a json string.
+func NewTempoAPISearchResponse(t *testing.T, s string) *TempoAPISearchResponse {
+	t.Helper()
+
+	res := &TempoAPISearchResponse{}
+	if err := json.Unmarshal([]byte(s), res); err != nil {
+		t.Fatalf("could not unmarshal tempo search response=%q: %s", s, err)
+	}
+	return res
+}
+
 // LogsQLQueryResponse is an in-memory representation of the
 // /select/logsql/query response.
 type LogsQLQueryResponse struct {

--- a/apptest/tests/tempo_span_events_test.go
+++ b/apptest/tests/tempo_span_events_test.go
@@ -1,0 +1,143 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/fs"
+	at "github.com/VictoriaMetrics/VictoriaTraces/apptest"
+	otelpb "github.com/VictoriaMetrics/VictoriaTraces/lib/protoparser/opentelemetry/pb"
+)
+
+// TestSingleTempoAPISearchSpanEvents checks that the Tempo API finds a span by its
+// events and links.
+//
+// Each event and link is stored under its own numbered field, so the assertions
+// deliberately cover both ends: most match the second event or link, and a pair match
+// the first, which proves the index wildcard spans every index rather than one of them.
+func TestSingleTempoAPISearchSpanEvents(t *testing.T) {
+	fs.MustRemoveDir(t.Name())
+
+	tc := at.NewTestCase(t)
+	defer tc.Stop()
+
+	sut := tc.MustStartDefaultVtsingle()
+
+	traceID := "aa5886e99fffef35a847cb2d493fde01"
+	// the linked ids differ from the span's own, so an assertion on link:traceID cannot
+	// pass by accidentally reading the span's trace_id field.
+	linkedTraceID0 := "cc5886e99fffef35a847cb2d493fde03"
+	linkedTraceID := "bb5886e99fffef35a847cb2d493fde02"
+	spanID := "12345678"
+	linkedSpanID := "87654321"
+	spanTime := time.Now()
+
+	stringValue := func(s string) *otelpb.AnyValue {
+		return &otelpb.AnyValue{StringValue: &s}
+	}
+
+	sut.OTLPHTTPExportTraces(t, &otelpb.ExportTraceServiceRequest{
+		ResourceSpans: []*otelpb.ResourceSpans{
+			{
+				Resource: otelpb.Resource{
+					Attributes: []*otelpb.KeyValue{
+						{Key: "service.name", Value: stringValue("spanEventService")},
+					},
+				},
+				ScopeSpans: []*otelpb.ScopeSpans{
+					{
+						Spans: []*otelpb.Span{
+							{
+								TraceID:           traceID,
+								SpanID:            spanID,
+								Name:              "spanEventOperation",
+								Kind:              otelpb.SpanKind(1),
+								StartTimeUnixNano: uint64(spanTime.UnixNano()),
+								EndTimeUnixNano:   uint64(spanTime.UnixNano()),
+								Events: []*otelpb.SpanEvent{
+									{
+										TimeUnixNano: uint64(spanTime.UnixNano()),
+										Name:         "first event",
+									},
+									{
+										TimeUnixNano: uint64(spanTime.UnixNano()),
+										Name:         "exception",
+										Attributes: []*otelpb.KeyValue{
+											{Key: "exception.type", Value: stringValue("OutOfMemoryError")},
+										},
+									},
+								},
+								Links: []*otelpb.SpanLink{
+									{
+										TraceID: linkedTraceID0,
+										SpanID:  spanID,
+									},
+									{
+										TraceID: linkedTraceID,
+										SpanID:  linkedSpanID,
+										Attributes: []*otelpb.KeyValue{
+											{Key: "link.kind", Value: stringValue("follows-from")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, at.QueryOpts{})
+	sut.ForceFlush(t)
+	time.Sleep(2 * time.Second) // index will be created after -insert.traceMaxDuration (2s in integration test)
+
+	f := func(traceQL string, wantTraceIDs []string) {
+		t.Helper()
+
+		tc.Assert(&at.AssertOptions{
+			Msg: "unexpected /select/tempo/api/search response for " + traceQL,
+			Got: func() any {
+				return sut.TempoAPISearch(t, traceQL, at.QueryOpts{}).TraceIDs()
+			},
+			Want:    wantTraceIDs,
+			CmpOpts: []cmp.Option{cmpopts.EquateEmpty()},
+		})
+	}
+
+	// the span itself is reachable, so a miss below is about the event, not the setup.
+	f(`{name="spanEventOperation"}`, []string{traceID})
+
+	// event index 1
+	f(`{event:name="exception"}`, []string{traceID})
+	f(`{event.exception.type="OutOfMemoryError"}`, []string{traceID})
+	f(`{event.exception.type=~"OutOfMemory.*"}`, []string{traceID})
+
+	// event index 0, so the wildcard must cover more than the last event
+	f(`{event:name="first event"}`, []string{traceID})
+
+	// link index 1
+	f(`{link.link.kind="follows-from"}`, []string{traceID})
+	f(`{link:traceID="`+linkedTraceID+`"}`, []string{traceID})
+	f(`{link:spanID="`+linkedSpanID+`"}`, []string{traceID})
+
+	// link index 0
+	f(`{link:traceID="`+linkedTraceID0+`"}`, []string{traceID})
+
+	f(`{event:name="no such event"}`, nil)
+	f(`{event.exception.type="NoSuchError"}`, nil)
+
+	// Each condition is matched on its own rather than pinned to one event, so this
+	// matches even though the `first event` entry carries no attributes. Documented in
+	// docs/victoriatraces/querying/README.md; pinned here so a change is deliberate.
+	f(`{event:name="first event" && event.exception.type="OutOfMemoryError"}`, []string{traceID})
+
+	// `= nil` reads across every event, so it is not the negation of `!= nil` on one
+	// event: it holds only when NO event carries the attribute. The span below has an
+	// event without `exception.type`, and `= nil` still does not match.
+	f(`{event.absent.attr = nil}`, []string{traceID})
+	f(`{event.exception.type = nil}`, nil)
+	f(`{event.exception.type != nil}`, []string{traceID})
+	f(`{event.absent.attr != nil}`, nil)
+}

--- a/apptest/vtsingle.go
+++ b/apptest/vtsingle.go
@@ -32,6 +32,8 @@ type Vtsingle struct {
 	jaegerAPITraceURL        string
 	jaegerAPIDependenciesURL string
 
+	tempoAPISearchURL string
+
 	logsQLQueryURL string
 
 	otlpTracesURL     string
@@ -78,6 +80,8 @@ func StartVtsingle(instance string, flags []string, cli *Client) (*Vtsingle, err
 		jaegerAPITracesURL:       fmt.Sprintf("http://%s/select/jaeger/api/traces", stderrExtracts[1]),
 		jaegerAPITraceURL:        fmt.Sprintf("http://%s/select/jaeger/api/traces/%%s", stderrExtracts[1]),
 		jaegerAPIDependenciesURL: fmt.Sprintf("http://%s/select/jaeger/api/dependencies", stderrExtracts[1]),
+
+		tempoAPISearchURL: fmt.Sprintf("http://%s/select/tempo/api/search", stderrExtracts[1]),
 
 		logsQLQueryURL: fmt.Sprintf("http://%s/select/logsql/query", stderrExtracts[1]),
 
@@ -173,6 +177,25 @@ func (app *Vtsingle) JaegerAPIDependencies(t *testing.T, param JaegerDependencie
 	}
 	res, _ := app.cli.Get(t, app.jaegerAPIDependenciesURL+paramsEnc)
 	return NewJaegerAPIDependenciesResponse(t, res)
+}
+
+// TempoAPISearch is a test helper function that searches for traces with a TraceQL
+// query by sending an HTTP GET request to /select/tempo/api/search Vtsingle endpoint.
+func (app *Vtsingle) TempoAPISearch(t *testing.T, traceQL string, opts QueryOpts) *TempoAPISearchResponse {
+	t.Helper()
+
+	q := url.Values{}
+	q.Add("q", traceQL)
+	for name, values := range opts.asURLValues() {
+		for _, value := range values {
+			q.Add(name, value)
+		}
+	}
+	res, statusCode := app.cli.Get(t, app.tempoAPISearchURL+"?"+q.Encode())
+	if statusCode != http.StatusOK {
+		t.Fatalf("unexpected status code from %s: %d; want %d", app.tempoAPISearchURL, statusCode, http.StatusOK)
+	}
+	return NewTempoAPISearchResponse(t, res)
 }
 
 func (app *Vtsingle) LogsQLQuery(t *testing.T, LogsQL string, opts QueryOpts) *LogsQLQueryResponse {

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* BUGFIX: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): match spans by their events and links in the Tempo search API, for example `{event:name = "exception"}`, `{event.exception.type = "OutOfMemoryError"}` and `{link:traceID = "..."}`. Previously these queries were accepted but never matched a span, because every event and link is stored under its own numbered field. `histogram_over_time` now rejects the event and link scopes, since it reads a single named field. The `event:timeSinceStart` intrinsic is not supported. See [this issue #118](https://github.com/VictoriaMetrics/VictoriaTraces/issues/118).
+
 ## [v0.11.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.11.0)
 
 Released at 2026-08-14

--- a/docs/victoriatraces/querying/README.md
+++ b/docs/victoriatraces/querying/README.md
@@ -259,7 +259,28 @@ Here's a response example:
 {"traces":[{"traceID":"c5acfeeaf4d64ac026da0c30d2513082","rootServiceName":"example-gateway","rootTraceName":"","startTimeUnixNano":1783567376769803488,"durationMs":3011,"spanSets":[{"spans":[{"spanID":"430871c05136c0b5","startTimeUnixNano":1783567376769803488,"durationNanos":3011746753,"attributes":[{"key":"service.name","value":{"stringValue":"frontend"}},{"key":"name","value":{"stringValue":"GET"}},{"key":"nestedSetParent","value":{"intValue":"0"}}]}],"matched":1}]}]}
 ```
 
-2. Querying a trace by ID
+2. Find traces which have a span carrying an `exception` event:
+
+```sh
+curl -G http://<victoria-traces>:10428/select/tempo/api/search \
+  --data-urlencode 'q={ event:name = "exception" }'
+```
+
+An `event.` or `event:name` condition matches any event of the span. A `link.`, `link:spanID`
+or `link:traceID` condition matches any link.
+
+Each condition is matched on its own, so
+`{ event:name = "exception" && event.exception.type = "OutOfMemoryError" }` also matches a span
+where one event is named `exception` and a different event carries the attribute. Use a single
+condition when you need to be sure which event matched.
+
+Comparisons against `nil` read across every event, so the two directions are not opposites of each
+other on a single event. `event.foo != nil` matches when any event carries `foo`, while
+`event.foo = nil` matches only when no event of the span carries it. Links behave the same way.
+
+The `event:timeSinceStart` intrinsic is not supported.
+
+3. Querying a trace by ID
 
 ```sh
 curl http://<victoria-traces>:10428/select/tempo/api/v2/traces/d8d8d9c6d1cdfa5344ef3d69b8b594d8
@@ -271,7 +292,7 @@ Here's a response example:
 {"trace":{"resourceSpans":[{"resource":{"attributes":[{"key":"docker.cli.cobra.command_path","value":{"stringValue":"docker%20compose"}},{"key":"service.name","value":{"stringValue":"frontend-proxy"}}]},"scopeSpans":[{"scope":{"name":"","version":"","attributes":[]},"spans":[{"traceId":"2NjZxtHN+lNE7z1puLWU2A==","spanId":"yuSYZPL61X8=","parentSpanId":"M+KIEWQP/FQ=","name":"router image-provider egress","kind":"SPAN_KIND_CLIENT","startTimeUnixNano":"1783062881157505553","endTimeUnixNano":"1783062881196836233","attributes":[{"key":"component","value":{"stringValue":"proxy"}},{"key":"http.protocol","value":{"stringValue":"HTTP/1.1"}}],"status":{}}]}]}]},"metrics":{"inspectedBytes":"0"}}
 ```
 
-3. Querying metrics of trace spans
+4. Querying metrics of trace spans
 
 ```sh
 curl -G http://<victoria-traces>:10428/select/tempo/api/metrics/query_range \

--- a/lib/traceql/filter_general.go
+++ b/lib/traceql/filter_general.go
@@ -112,15 +112,25 @@ func (fc *filterCommon) String() string {
 	}
 
 	// TraceQL's `attr = nil` / `attr != nil` map to LogsQL's empty-value and
-	// any-value filters respectively — the canonical forms per
+	// any-value filters, the canonical forms per
 	// https://docs.victoriametrics.com/victorialogs/logsql/#empty-value-filter
 	// and https://docs.victoriametrics.com/victorialogs/logsql/#any-value-filter.
+	//
+	// Event and link fields take the negated any-value filter for `= nil` instead. This
+	// also flips the quantifier: `event.foo != nil` holds when any event carries `foo`,
+	// while `event.foo = nil` holds only when no event carries it.
 	if fc.value == "nil" {
+		vtField := fc.tagToVTField()
 		switch fc.op {
 		case "=":
-			return quoteFieldNameIfNeeded(fc.tagToVTField()) + `:""`
+			if strings.HasSuffix(vtField, eventLinkIndexWildcard) {
+				// An empty-value filter only visits the fields a span really has, so it can
+				// never fire on an attribute no event carries.
+				return `!` + quoteFieldNameIfNeeded(vtField) + `:*`
+			}
+			return quoteFieldNameIfNeeded(vtField) + `:""`
 		case "!=":
-			return quoteFieldNameIfNeeded(fc.tagToVTField()) + ":*"
+			return quoteFieldNameIfNeeded(vtField) + ":*"
 		}
 	}
 
@@ -161,20 +171,35 @@ func (fc *filterCommon) tagToVTField() string {
 	return TraceQLFieldToVTField(fc.fieldName)
 }
 
+// eventLinkIndexWildcard matches every event and every link of a span.
+//
+// Each event and link is stored under its own numbered field, so a span with two
+// events holds event:event_name:0 and event:event_name:1. TraceQL has no syntax
+// for a single event index, so a query on an event or link field must match them all.
+const eventLinkIndexWildcard = ":*"
+
 // TraceQLFieldToVTField converts a TraceQL field name to a VictoriaTraces internal field name.
 // e.g., "resource.service.name" -> "resource_attr:service.name"
 //
 //	"span.http.status_code" -> "span_attr:http.status_code"
 //	"status"                -> "status_code"
+//	"event.exception.type"  -> "event:event_attr:exception.type:*"
+//	"event:name"            -> "event:event_name:*"
 func TraceQLFieldToVTField(fieldName string) string {
 	if strings.HasPrefix(fieldName, "resource.") {
 		return otelpb.ResourceAttrPrefix + fieldName[len("resource."):]
 	} else if strings.HasPrefix(fieldName, "span.") {
 		return otelpb.SpanAttrPrefixField + fieldName[len("span."):]
 	} else if strings.HasPrefix(fieldName, "event.") {
-		return otelpb.EventPrefix + otelpb.EventAttrPrefix + fieldName[len("event."):]
+		return otelpb.EventPrefix + otelpb.EventAttrPrefix + fieldName[len("event."):] + eventLinkIndexWildcard
 	} else if strings.HasPrefix(fieldName, "link.") {
-		return otelpb.LinkPrefix + otelpb.LinkAttrPrefix + fieldName[len("link."):]
+		return otelpb.LinkPrefix + otelpb.LinkAttrPrefix + fieldName[len("link."):] + eventLinkIndexWildcard
+	} else if fieldName == "event:name" {
+		return otelpb.EventPrefix + otelpb.EventNameField + eventLinkIndexWildcard
+	} else if fieldName == "link:spanID" {
+		return otelpb.LinkPrefix + otelpb.LinkSpanIDField + eventLinkIndexWildcard
+	} else if fieldName == "link:traceID" {
+		return otelpb.LinkPrefix + otelpb.LinkTraceIDField + eventLinkIndexWildcard
 	} else if strings.HasPrefix(fieldName, "instrumentation.") {
 		return otelpb.InstrumentationScopeAttrPrefix + fieldName[len("instrumentation."):]
 	} else if fieldName == "status" {
@@ -186,12 +211,42 @@ func TraceQLFieldToVTField(fieldName string) string {
 	return fieldName
 }
 
+// trimEventLinkIndex drops the trailing event or link index from a stored field name,
+// e.g. "event:event_name:0" -> "event:event_name". It also accepts the ":*" wildcard
+// written by TraceQLFieldToVTField, so the two functions round-trip.
+func trimEventLinkIndex(fieldName string) string {
+	i := strings.LastIndexByte(fieldName, ':')
+	if i < 0 {
+		return fieldName
+	}
+	suffix := fieldName[i+1:]
+	if suffix == "*" {
+		return fieldName[:i]
+	}
+	if suffix == "" {
+		return fieldName
+	}
+	for _, c := range suffix {
+		if c < '0' || c > '9' {
+			return fieldName
+		}
+	}
+	return fieldName[:i]
+}
+
 // VTFieldToTraceQL converts a VictoriaTraces internal field name back to a TraceQL field name.
 // e.g., "resource_attr:service.name" -> "resource.service.name"
 //
-//	"span_attr:http.status_code" -> "span.http.status_code"
-//	"status_code"                -> "status"
+//	"span_attr:http.status_code"       -> "span.http.status_code"
+//	"status_code"                      -> "status"
+//	"event:event_attr:exception.type:0" -> "event.exception.type"
+//	"event:event_name:0"               -> "event:name"
 func VTFieldToTraceQL(fieldName string) string {
+	// Events and links carry a per-event index which TraceQL cannot express.
+	if strings.HasPrefix(fieldName, otelpb.EventPrefix) || strings.HasPrefix(fieldName, otelpb.LinkPrefix) {
+		fieldName = trimEventLinkIndex(fieldName)
+	}
+
 	if strings.HasPrefix(fieldName, otelpb.ResourceAttrPrefix) {
 		return "resource." + fieldName[len(otelpb.ResourceAttrPrefix):]
 	} else if strings.HasPrefix(fieldName, otelpb.SpanAttrPrefixField) {
@@ -200,6 +255,12 @@ func VTFieldToTraceQL(fieldName string) string {
 		return "event." + fieldName[len(otelpb.EventPrefix+otelpb.EventAttrPrefix):]
 	} else if strings.HasPrefix(fieldName, otelpb.LinkPrefix+otelpb.LinkAttrPrefix) {
 		return "link." + fieldName[len(otelpb.LinkPrefix+otelpb.LinkAttrPrefix):]
+	} else if fieldName == otelpb.EventPrefix+otelpb.EventNameField {
+		return "event:name"
+	} else if fieldName == otelpb.LinkPrefix+otelpb.LinkSpanIDField {
+		return "link:spanID"
+	} else if fieldName == otelpb.LinkPrefix+otelpb.LinkTraceIDField {
+		return "link:traceID"
 	} else if strings.HasPrefix(fieldName, otelpb.InstrumentationScopeAttrPrefix) {
 		return "instrumentation." + fieldName[len(otelpb.InstrumentationScopeAttrPrefix):]
 	} else if fieldName == otelpb.StatusCodeField {

--- a/lib/traceql/parser_test.go
+++ b/lib/traceql/parser_test.go
@@ -107,6 +107,24 @@ func TestParseQuery(t *testing.T) {
 
 	// Regex match operator `=~` must become LogsQL `~` (not `=~`).
 	f(`{resource.host.name =~ "kimi-k2-a.*"}`, `"resource_attr:host.name":~"kimi-k2-a.*"`)
+
+	// Span events and links are stored one numbered field per event, so every
+	// event and link field carries the ":*" index wildcard.
+	f(`{event.exception.type = "OOM"}`, `"event:event_attr:exception.type:*":=OOM`)
+	f(`{event.exception.type =~ "OOM.*"}`, `"event:event_attr:exception.type:*":~"OOM.*"`)
+	f(`{event:name = "exception"}`, `"event:event_name:*":=exception`)
+	f(`{link.foo = "bar"}`, `"link:link_attr:foo:*":=bar`)
+	f(`{link:spanID = "0102030405060708"}`, `"link:link_span_id:*":=0102030405060708`)
+	f(`{link:traceID = "0102030405060708090a0b0c0d0e0f10"}`, `"link:link_trace_id:*":=0102030405060708090a0b0c0d0e0f10`)
+
+	// `= nil` on a wildcard field cannot use the empty-value filter, because that
+	// filter only visits the fields a span really has. It becomes a negated
+	// any-value filter instead. `span.` keeps the empty-value form.
+	f(`{event.exception.type = nil}`, `!"event:event_attr:exception.type:*":*`)
+	f(`{link.foo = nil}`, `!"link:link_attr:foo:*":*`)
+	f(`{event:name = nil}`, `!"event:event_name:*":*`)
+	f(`{span.http.status_code = nil}`, `"span_attr:http.status_code":""`)
+	f(`{event.exception.type != nil}`, `"event:event_attr:exception.type:*":*`)
 }
 
 // TestParseQueryInvalid asserts that malformed inputs return an error

--- a/lib/traceql/pipe_metrics_test.go
+++ b/lib/traceql/pipe_metrics_test.go
@@ -268,6 +268,12 @@ func TestTraceQLFieldToVTField(t *testing.T) {
 	f("service.name", "resource_attr:service.name")
 	f("duration", "duration")
 	f("name", "name")
+
+	f("event.exception.type", "event:event_attr:exception.type:*")
+	f("event:name", "event:event_name:*")
+	f("link.foo", "link:link_attr:foo:*")
+	f("link:spanID", "link:link_span_id:*")
+	f("link:traceID", "link:link_trace_id:*")
 }
 
 func TestVTFieldToTraceQL(t *testing.T) {
@@ -284,6 +290,13 @@ func TestVTFieldToTraceQL(t *testing.T) {
 	f("status_code", "status")
 	f("duration", "duration")
 	f("name", "name")
+
+	// Stored event and link fields carry the index of the event they belong to.
+	f("event:event_attr:exception.type:0", "event.exception.type")
+	f("event:event_name:1", "event:name")
+	f("link:link_attr:foo:0", "link.foo")
+	f("link:link_span_id:0", "link:spanID")
+	f("link:link_trace_id:2", "link:traceID")
 }
 
 func TestFieldMappingRoundTrip(t *testing.T) {
@@ -293,6 +306,11 @@ func TestFieldMappingRoundTrip(t *testing.T) {
 		"status",
 		"duration",
 		"name",
+		"event.exception.type",
+		"event:name",
+		"link.foo",
+		"link:spanID",
+		"link:traceID",
 	}
 	for _, field := range fields {
 		vt := TraceQLFieldToVTField(field)


### PR DESCRIPTION
Part of #118. This covers the Tempo half only, so the issue stays open for Jaeger.

`{event.exception.type = "OutOfMemoryError"}` parses fine today and returns nothing.
So does `{event:name = "exception"}`, and so does every link query.

The reason is the storage layout. Each event and link of a span is stored under its
own numbered field, so a span with two events holds `event:event_name:0` and
`event:event_name:1`. `TraceQLFieldToVTField` mapped `event.exception.type` to
`event:event_attr:exception.type`, a name no span ever has. The query matched nothing
and returned 200 with an empty list, which reads as "no traces found".

This adds the `:*` index wildcard, and the intrinsics which had no mapping at all:

| TraceQL | now maps to |
| --- | --- |
| `event.<key>` | `event:event_attr:<key>:*` |
| `link.<key>` | `link:link_attr:<key>:*` |
| `event:name` | `event:event_name:*` |
| `link:spanID` | `link:link_span_id:*` |
| `link:traceID` | `link:link_trace_id:*` |

`VTFieldToTraceQL` drops the index in the other direction, since it is fed real stored
names such as `event:event_attr:exception.type:0`.

Links were not mentioned in the issue, but they carry the same defect from the same two
lines, so fixing events alone would have left half of it.

Two knock-on cases the wildcard forces:

`= nil` cannot stay an empty-value filter. That filter only visits the fields a span
really has, so on a wildcard name it can never fire. It becomes a negated any-value
filter, `!"event:event_attr:foo:*":*`. Without this, `{event.foo = nil}` returned nothing
for every span. On master it matched every span instead, because the un-indexed name
never existed, so it was only ever right by accident. `span.` keeps the empty-value form.

That also flips the quantifier, which the docs now state: `event.foo != nil` holds when
any event carries `foo`, while `event.foo = nil` holds only when no event carries it.

`histogram_over_time` now returns an error for the event and link scopes.
`histogram()` reads a single named field and rejects a wildcard, so the generated LogsQL
failed to parse and surfaced an internal field name to the user. It fails early in
`metricsToLogsQLStats` instead. `min`, `max`, `avg`, `sum` and `quantile` do accept the
wildcard and now aggregate across every event index.

### Known behaviour worth stating

Each condition is matched on its own rather than pinned to one event. So
`{event:name = "exception" && event.exception.type = "OutOfMemoryError"}` also matches a
span where one event is named `exception` and a different event carries the attribute.
This is in the docs and pinned by a test, so a future change to it is deliberate. Tell me
if you would rather it were an error until it can be done properly.

### Not included

`event:timeSinceStart` is the event timestamp minus the span start time. That is
arithmetic, not a field rename, so it does not fit here.

The `event` and `link` scopes of `/api/v2/search/tags` stay disabled, and
`/api/v2/search/tag/event.<key>/values` still returns nothing. The wildcard works in a
filter but not in the `field_values` pipe, which reads a single named field. I checked:
`field_values "event:event_attr:exception.type:*"` reports hits with an empty value
rather than expanding the wildcard. I left a comment at the mapping in
`processSearchTagValuesRequest` explaining why it must not copy the wildcard, since it
is easy to mistake for an oversight.

The Jaeger API is untouched. Its `tags` param maps every bare key to `span_attr:`
(`app/vtselect/traces/jaeger/jaeger.go:369-385`), so events are unreachable there too.
Jaeger itself matches a tag key against span logs as well, so following it would widen
what a bare key means today. That is a call for the maintainers, so I asked on the issue
rather than assume.

### Performance

The `:*` wildcard makes the filter test every field name in a block, so cost grows with
the number of events per span. Measured on a single node, median of 11 runs, comparing
filters that match exactly the same spans:

| events per span | distinct field names | concrete field | event wildcard | zero-hit event name |
| --- | --- | --- | --- | --- |
| 1 | ~10 | 1 ms | 1 ms | 1 ms |
| 100 | 420 | 1 ms | 2 ms | 4 ms |
| 240 | 980 | 2 ms | 2 ms | 10 ms |

End to end through `/select/tempo/api/search` on the last row: 34 ms for a span
attribute, 35 ms for an event attribute, 40 ms for a zero-hit event name.

The worst case is bounded. A span carrying more events is dropped at ingestion, because
each event costs 4 fields and `-insert.maxFieldsPerLine` defaults to 1000, so roughly
240 events per span is the ceiling. The 240 row above is that ceiling, not an arbitrary
number.

This was one node on a laptop with up to 50k spans per stream. I did not test cluster
scale.

### Tests

`lib/traceql`: both mapping directions, and the LogsQL that a query renders to.

`apptest/tests/tempo_span_events_test.go`: ingests one span with two events and two
links, then searches through `/select/tempo/api/search`. Most assertions target the
second event or link, and two target the first, so the wildcard has to cover every index
rather than one end. A control assertion on `{name=...}` proves the span is reachable,
negative assertions prove the filters are not matching everything, and four cover the
`nil` cases in both directions.

`app/vtselect/traces/tempo`: `histogram_over_time` on an event or link field errors. The
five aggregations which do accept the wildcard have the LogsQL they generate fed back
through `ParseQueryAtTimestamp`, so a query reaching the storage layer is proven valid
rather than assumed.

One gap I left alone: `by (event.foo)` still groups on a name no span has, giving one
empty group. That is what master did too, so it is not a regression, but it is
inconsistent with the error `histogram_over_time` now returns for the same scope. Say the
word if you would rather both errored.

All fail without the change, and I mutation-checked each: revert, rebuild the binary,
watch them fail, restore.

`make check-all` passes apart from `golangci-lint`, which will not run against a Go
toolchain newer than the one it was built with. Full test run is green for `./lib/...`,
`./app/...` and `./apptest/...`.
