### PR TITLE
Remove ID fields from dashboards

### DIFF
--- a/dashboards/victoriatraces-cluster.json
+++ b/dashboards/victoriatraces-cluster.json
@@ -50,7 +50,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/victoriatraces.json
+++ b/dashboards/victoriatraces.json
@@ -73,7 +73,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/victoriatraces-cluster.json
+++ b/dashboards/vm/victoriatraces-cluster.json
@@ -51,7 +51,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [
     {
       "icon": "doc",

--- a/dashboards/vm/victoriatraces.json
+++ b/dashboards/vm/victoriatraces.json
@@ -74,7 +74,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
   "links": [
     {
       "icon": "doc",


### PR DESCRIPTION
### Describe Your Changes

Remove id fields in dashboards. This prevents possible import errors in Grafana v13.1.0 and later.

Similar to: VictoriaMetrics/VictoriaMetrics#11411

### Checklist

The following checks are **mandatory**:

- [x] My change adheres to [VictoriaMetrics contributing guidelines](https://docs.victoriametrics.com/victoriametrics/contributing/#pull-request-checklist).
- [x] My change adheres to [VictoriaMetrics development goals](https://docs.victoriametrics.com/victoriametrics/goals/).
