### PR TITLE
feature: properly handle HTTP/2 handshake request PRI *

### DIFF
--- a/app/victoria-traces/main.go
+++ b/app/victoria-traces/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -103,11 +102,7 @@ func httpRequestHandler(w http.ResponseWriter, r *http.Request) bool {
 		// HTTP/2 support on the backend to enable streaming features.
 		// Since this support is currently unnecessary, we handle these requests
 		// with a 405 Method Not Allowed status code to eliminate noisy logs.
-		err := &httpserver.ErrorWithStatusCode{
-			Err:        errors.New("HTTP/2 is currently not supported on this port"),
-			StatusCode: http.StatusMethodNotAllowed,
-		}
-		httpserver.Errorf(w, r, "%s", err)
+		http.Error(w, "HTTP/2 is currently not supported on this port", http.StatusMethodNotAllowed)
 		return true
 	}
 

--- a/app/victoria-traces/main.go
+++ b/app/victoria-traces/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -94,6 +95,19 @@ func httpRequestHandler(w http.ResponseWriter, r *http.Request) bool {
 			{"metrics", "available service metrics"},
 			{"flags", "command-line flags"},
 		})
+		return true
+	}
+
+	if r.Method == "PRI" && r.URL.Path == "*" {
+		// Typically, this request originates from clients (e.g., Grafana) testing
+		// HTTP/2 support on the backend to enable streaming features.
+		// Since this support is currently unnecessary, we handle these requests
+		// with a 405 Method Not Allowed status code to eliminate noisy logs.
+		err := &httpserver.ErrorWithStatusCode{
+			Err:        errors.New("HTTP/2 is currently not supported on this port"),
+			StatusCode: http.StatusMethodNotAllowed,
+		}
+		httpserver.Errorf(w, r, "%s", err)
 		return true
 	}
 

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,7 +12,7 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
-* FEATURE: [vtagent](https://docs.victoriametrics.com/victoriatraces/vtagent/)[Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): properly handle HTTP/2 handshake requests (`PRI *`) from clients such as the Grafana Tempo datasource to eliminate unnecessary warning logs.
+* FEATURE: [Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): properly handle HTTP/2 handshake requests (`PRI *`) from clients such as the Grafana Tempo datasource to eliminate unnecessary warning logs.
 
 ## [v0.11.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.11.0)
 

--- a/docs/victoriatraces/changelog/CHANGELOG.md
+++ b/docs/victoriatraces/changelog/CHANGELOG.md
@@ -12,6 +12,8 @@ The following `tip` changes can be tested by building VictoriaTraces components 
 
 ## tip
 
+* FEATURE: [vtagent](https://docs.victoriametrics.com/victoriatraces/vtagent/)[Single-node VictoriaTraces](https://docs.victoriametrics.com/victoriatraces/) and vtselect in [VictoriaTraces cluster](https://docs.victoriametrics.com/victoriatraces/cluster/): properly handle HTTP/2 handshake requests (`PRI *`) from clients such as the Grafana Tempo datasource to eliminate unnecessary warning logs.
+
 ## [v0.11.0](https://github.com/VictoriaMetrics/VictoriaTraces/releases/tag/v0.11.0)
 
 Released at 2026-08-14


### PR DESCRIPTION
properly handle HTTP/2 handshake requests (`PRI *`) from clients such as the Grafana Tempo datasource to eliminate unnecessary warning logs.